### PR TITLE
Add PHP todo app with admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,57 @@
-# todoapp7
-todoapp7
+# Todo App
+
+A responsive PHP/MySQL Todo application with a Bootstrap front end. Users can manage their personal tasks while administrators have access to a dedicated dashboard protected by a sample login (`admin`/`admin`).
+
+## Features
+
+- Task CRUD (create, read, update, delete) operations from the public interface
+- Responsive Bootstrap 5 UI with Font Awesome icons and jQuery-powered modals
+- Track task status (pending/completed) and due dates
+- Admin dashboard for managing tasks, including statistics and quick actions
+- Flash messaging for user feedback
+
+## Requirements
+
+- PHP 8.1+
+- MySQL 5.7+
+- Web server capable of running PHP applications (Apache/Nginx or PHP built-in server)
+
+## Installation
+
+1. Clone the repository and install the dependencies (none required beyond PHP extensions `pdo` and `pdo_mysql`).
+2. Import the database schema:
+
+   ```bash
+   mysql -u root -p < database.sql
+   ```
+
+   Adjust the credentials as needed for your environment.
+
+3. Update the database connection settings in [`config.php`](config.php) to match your MySQL credentials.
+4. Serve the application (for example with PHP's built-in server):
+
+   ```bash
+   php -S localhost:8000
+   ```
+
+5. Visit `http://localhost:8000/index.php` for the public todo list.
+6. Visit `http://localhost:8000/admin/login.php` and use the credentials `admin` / `admin` to access the admin dashboard.
+
+## Project Structure
+
+```
+├── admin
+│   ├── dashboard.php   # Admin dashboard with CRUD operations
+│   ├── login.php       # Sample login (admin/admin)
+│   └── logout.php      # Destroy the admin session
+├── config.php          # Database configuration
+├── database.sql        # MySQL schema
+├── functions.php       # Shared database helper functions
+├── index.php           # Public todo interface
+└── README.md
+```
+
+## Security Notes
+
+- The admin login is intentionally simple for demonstration. Replace with a secure authentication system before using in production.
+- Configure proper error handling and SSL/TLS in production environments.

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+session_start();
+
+if (!($_SESSION['admin_authenticated'] ?? false)) {
+    header('Location: login.php');
+    exit;
+}
+
+require_once __DIR__ . '/../functions.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+
+    try {
+        switch ($action) {
+            case 'create':
+                $title = trim($_POST['title'] ?? '');
+                $description = trim($_POST['description'] ?? '');
+                $dueDate = $_POST['due_date'] !== '' ? $_POST['due_date'] : null;
+
+                if ($title === '' || $description === '') {
+                    throw new InvalidArgumentException('Title and description are required.');
+                }
+
+                createTask($title, $description, $dueDate);
+                $_SESSION['flash'] = ['type' => 'success', 'message' => 'Task created successfully.'];
+                break;
+            case 'update':
+                $id = (int) ($_POST['id'] ?? 0);
+                $title = trim($_POST['title'] ?? '');
+                $description = trim($_POST['description'] ?? '');
+                $dueDate = $_POST['due_date'] !== '' ? $_POST['due_date'] : null;
+                $status = $_POST['status'] ?? 'pending';
+
+                if ($id <= 0 || $title === '' || $description === '') {
+                    throw new InvalidArgumentException('All fields are required for updating a task.');
+                }
+
+                updateTask($id, $title, $description, $dueDate, $status === 'completed' ? 'completed' : 'pending');
+                $_SESSION['flash'] = ['type' => 'success', 'message' => 'Task updated successfully.'];
+                break;
+            case 'delete':
+                $id = (int) ($_POST['id'] ?? 0);
+                if ($id <= 0) {
+                    throw new InvalidArgumentException('Invalid task selected for deletion.');
+                }
+
+                deleteTask($id);
+                $_SESSION['flash'] = ['type' => 'success', 'message' => 'Task deleted successfully.'];
+                break;
+            case 'toggle':
+                $id = (int) ($_POST['id'] ?? 0);
+                if ($id <= 0) {
+                    throw new InvalidArgumentException('Invalid task selected for update.');
+                }
+
+                toggleTaskStatus($id);
+                $_SESSION['flash'] = ['type' => 'success', 'message' => 'Task status updated.'];
+                break;
+            default:
+                throw new InvalidArgumentException('Unknown action requested.');
+        }
+    } catch (Throwable $exception) {
+        $_SESSION['flash'] = ['type' => 'danger', 'message' => $exception->getMessage()];
+    }
+
+    header('Location: ' . $_SERVER['PHP_SELF']);
+    exit;
+}
+
+$tasks = fetchTasks();
+$counts = taskCountsByStatus();
+$flash = $_SESSION['flash'] ?? null;
+unset($_SESSION['flash']);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Dashboard - Todo App</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-9usAa6m8y+Vd2r1dT1dQYxYDs2WdGEylZm4+c2R/g+kPgX9nuSUXGKmEcg2YkdE+5EYXPL3x4lrFZ9+fkDaog==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <div class="container">
+        <a class="navbar-brand" href="dashboard.php"><i class="fa-solid fa-gauge-high me-2"></i>Admin Dashboard</a>
+        <div class="d-flex align-items-center text-white">
+            <span class="me-3"><i class="fa-solid fa-user me-1"></i><?= htmlspecialchars((string) ($_SESSION['admin_username'] ?? 'admin'), ENT_QUOTES, 'UTF-8') ?></span>
+            <a class="btn btn-outline-light" href="logout.php"><i class="fa-solid fa-right-from-bracket me-1"></i>Logout</a>
+        </div>
+    </div>
+</nav>
+<div class="container mb-5">
+    <?php if ($flash): ?>
+        <div class="alert alert-<?= htmlspecialchars($flash['type'], ENT_QUOTES, 'UTF-8') ?> alert-dismissible fade show" role="alert">
+            <?= htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8') ?>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    <?php endif; ?>
+
+    <div class="row g-4 mb-4">
+        <div class="col-sm-4">
+            <div class="card shadow-sm border-0">
+                <div class="card-body text-center">
+                    <h5 class="card-title text-muted">Total Tasks</h5>
+                    <p class="display-6 mb-0"><?= count($tasks) ?></p>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-4">
+            <div class="card shadow-sm border-0">
+                <div class="card-body text-center">
+                    <h5 class="card-title text-muted">Pending</h5>
+                    <p class="display-6 text-warning mb-0"><?= $counts['pending'] ?></p>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-4">
+            <div class="card shadow-sm border-0">
+                <div class="card-body text-center">
+                    <h5 class="card-title text-muted">Completed</h5>
+                    <p class="display-6 text-success mb-0"><?= $counts['completed'] ?></p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0 mb-4">
+        <div class="card-body">
+            <h2 class="h5 mb-3">Create Task</h2>
+            <form method="post" class="row g-3">
+                <input type="hidden" name="action" value="create">
+                <div class="col-md-6">
+                    <label for="title" class="form-label">Title</label>
+                    <input type="text" class="form-control" id="title" name="title" required>
+                </div>
+                <div class="col-md-6">
+                    <label for="due_date" class="form-label">Due Date</label>
+                    <input type="date" class="form-control" id="due_date" name="due_date">
+                </div>
+                <div class="col-12">
+                    <label for="description" class="form-label">Description</label>
+                    <textarea class="form-control" id="description" name="description" rows="3" required></textarea>
+                </div>
+                <div class="col-12 text-end">
+                    <button type="submit" class="btn btn-primary"><i class="fa-solid fa-plus me-2"></i>Add Task</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th scope="col">Title</th>
+                            <th scope="col">Description</th>
+                            <th scope="col">Due Date</th>
+                            <th scope="col">Status</th>
+                            <th scope="col" class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    <?php if ($tasks): ?>
+                        <?php foreach ($tasks as $task): ?>
+                            <tr data-task='<?= json_encode($task, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?>'>
+                                <td class="fw-semibold"><?= htmlspecialchars($task['title'], ENT_QUOTES, 'UTF-8') ?></td>
+                                <td><?= nl2br(htmlspecialchars($task['description'], ENT_QUOTES, 'UTF-8')) ?></td>
+                                <td><?= $task['due_date'] ? htmlspecialchars($task['due_date'], ENT_QUOTES, 'UTF-8') : '—' ?></td>
+                                <td>
+                                    <span class="badge <?= $task['status'] === 'completed' ? 'bg-success' : 'bg-warning text-dark' ?>">
+                                        <?= ucfirst($task['status']) ?>
+                                    </span>
+                                </td>
+                                <td class="text-end">
+                                    <div class="btn-group" role="group">
+                                        <form method="post" class="me-2">
+                                            <input type="hidden" name="action" value="toggle">
+                                            <input type="hidden" name="id" value="<?= (int) $task['id'] ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-secondary" title="Toggle status">
+                                                <i class="fa-solid fa-rotate"></i>
+                                            </button>
+                                        </form>
+                                        <button type="button" class="btn btn-sm btn-outline-primary me-2 btn-edit" data-bs-toggle="modal" data-bs-target="#editTaskModal">
+                                            <i class="fa-solid fa-pen"></i>
+                                        </button>
+                                        <form method="post" onsubmit="return confirm('Delete this task?');">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="id" value="<?= (int) $task['id'] ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Delete">
+                                                <i class="fa-solid fa-trash"></i>
+                                            </button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php else: ?>
+                        <tr>
+                            <td colspan="5" class="text-center py-4 text-muted">No tasks available.</td>
+                        </tr>
+                    <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="editTaskModal" tabindex="-1" aria-labelledby="editTaskModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form method="post">
+                <input type="hidden" name="action" value="update">
+                <input type="hidden" name="id" id="edit-id">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="editTaskModalLabel">Edit Task</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="edit-title" class="form-label">Title</label>
+                        <input type="text" class="form-control" id="edit-title" name="title" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="edit-description" class="form-label">Description</label>
+                        <textarea class="form-control" id="edit-description" name="description" rows="3" required></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="edit-due-date" class="form-label">Due Date</label>
+                        <input type="date" class="form-control" id="edit-due-date" name="due_date">
+                    </div>
+                    <div class="mb-3">
+                        <label for="edit-status" class="form-label">Status</label>
+                        <select class="form-select" id="edit-status" name="status">
+                            <option value="pending">Pending</option>
+                            <option value="completed">Completed</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Update Task</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+    $(function () {
+        $('.btn-edit').on('click', function () {
+            const row = $(this).closest('tr');
+            const data = row.data('task');
+            if (!data) {
+                return;
+            }
+
+            $('#edit-id').val(data.id);
+            $('#edit-title').val(data.title);
+            $('#edit-description').val(data.description);
+            $('#edit-due-date').val(data.due_date);
+            $('#edit-status').val(data.status);
+        });
+    });
+</script>
+</body>
+</html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+session_start();
+
+const ADMIN_USER = 'admin';
+const ADMIN_PASS = 'admin';
+
+if (isset($_SESSION['admin_authenticated']) && $_SESSION['admin_authenticated'] === true) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = trim($_POST['password'] ?? '');
+
+    if ($username === ADMIN_USER && $password === ADMIN_PASS) {
+        $_SESSION['admin_authenticated'] = true;
+        $_SESSION['admin_username'] = $username;
+        header('Location: dashboard.php');
+        exit;
+    }
+
+    $error = 'Invalid credentials. Please try again.';
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Login - Todo App</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-9usAa6m8y+Vd2r1dT1dQYxYDs2WdGEylZm4+c2R/g+kPgX9nuSUXGKmEcg2YkdE+5EYXPL3x4lrFZ9+fkDaog==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-6 col-lg-4">
+            <div class="card shadow-sm">
+                <div class="card-body p-4">
+                    <h1 class="h4 text-center mb-4"><i class="fa-solid fa-user-shield me-2"></i>Admin Login</h1>
+                    <?php if ($error): ?>
+                        <div class="alert alert-danger" role="alert">
+                            <?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?>
+                        </div>
+                    <?php endif; ?>
+                    <form method="post" novalidate>
+                        <div class="mb-3">
+                            <label for="username" class="form-label">Username</label>
+                            <input type="text" class="form-control" id="username" name="username" required autofocus>
+                        </div>
+                        <div class="mb-3">
+                            <label for="password" class="form-label">Password</label>
+                            <input type="password" class="form-control" id="password" name="password" required>
+                        </div>
+                        <div class="d-grid">
+                            <button type="submit" class="btn btn-primary">Login</button>
+                        </div>
+                    </form>
+                    <div class="text-center mt-3">
+                        <a href="../index.php" class="text-decoration-none"><i class="fa-solid fa-arrow-left me-1"></i>Back to app</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+session_start();
+
+$_SESSION = [];
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], (bool) $params['secure'], (bool) $params['httponly']);
+}
+session_destroy();
+
+header('Location: login.php');
+exit;

--- a/config.php
+++ b/config.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+const DB_HOST = 'localhost';
+const DB_NAME = 'todoapp';
+const DB_USER = 'root';
+const DB_PASS = '';
+
+/**
+ * Create a shared PDO connection using configuration constants.
+ */
+function getPDO(): PDO
+{
+    static $pdo = null;
+
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+
+    $dsn = sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4', DB_HOST, DB_NAME);
+    $options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ];
+
+    try {
+        $pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
+    } catch (PDOException $e) {
+        http_response_code(500);
+        echo '<h1>Database connection error</h1>';
+        echo '<p>Please check your database configuration in <code>config.php</code>.';
+        echo ' Error details: ' . htmlspecialchars($e->getMessage(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</p>';
+        exit;
+    }
+
+    return $pdo;
+}

--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,12 @@
+CREATE DATABASE IF NOT EXISTS `todoapp` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE `todoapp`;
+
+CREATE TABLE IF NOT EXISTS `tasks` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `title` VARCHAR(255) NOT NULL,
+  `description` TEXT NOT NULL,
+  `due_date` DATE DEFAULT NULL,
+  `status` ENUM('pending', 'completed') NOT NULL DEFAULT 'pending',
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/config.php';
+
+/**
+ * Retrieve all tasks ordered by creation date.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function fetchTasks(): array
+{
+    $pdo = getPDO();
+    $stmt = $pdo->query('SELECT * FROM tasks ORDER BY created_at DESC');
+
+    return $stmt->fetchAll();
+}
+
+/**
+ * Insert a new task into the database.
+ */
+function createTask(string $title, string $description, ?string $dueDate): void
+{
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('INSERT INTO tasks (title, description, due_date) VALUES (:title, :description, :due_date)');
+    $stmt->execute([
+        'title' => $title,
+        'description' => $description,
+        'due_date' => $dueDate,
+    ]);
+}
+
+/**
+ * Update an existing task.
+ */
+function updateTask(int $id, string $title, string $description, ?string $dueDate, string $status): void
+{
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('UPDATE tasks SET title = :title, description = :description, due_date = :due_date, status = :status WHERE id = :id');
+    $stmt->execute([
+        'title' => $title,
+        'description' => $description,
+        'due_date' => $dueDate,
+        'status' => $status,
+        'id' => $id,
+    ]);
+}
+
+/**
+ * Delete a task by id.
+ */
+function deleteTask(int $id): void
+{
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('DELETE FROM tasks WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+/**
+ * Toggle the completion status of a task.
+ */
+function toggleTaskStatus(int $id): void
+{
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('UPDATE tasks SET status = IF(status = "completed", "pending", "completed") WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+}
+
+/**
+ * Count tasks grouped by their status.
+ *
+ * @return array<string, int>
+ */
+function taskCountsByStatus(): array
+{
+    $pdo = getPDO();
+    $stmt = $pdo->query('SELECT status, COUNT(*) AS total FROM tasks GROUP BY status');
+    $rows = $stmt->fetchAll();
+
+    $counts = ['pending' => 0, 'completed' => 0];
+    foreach ($rows as $row) {
+        $status = $row['status'];
+        if (array_key_exists($status, $counts)) {
+            $counts[$status] = (int) $row['total'];
+        }
+    }
+
+    return $counts;
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+session_start();
+
+require_once __DIR__ . '/functions.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+
+    try {
+        switch ($action) {
+            case 'create':
+                $title = trim($_POST['title'] ?? '');
+                $description = trim($_POST['description'] ?? '');
+                $dueDate = $_POST['due_date'] !== '' ? $_POST['due_date'] : null;
+
+                if ($title === '' || $description === '') {
+                    throw new InvalidArgumentException('Title and description are required.');
+                }
+
+                createTask($title, $description, $dueDate);
+                $_SESSION['flash'] = ['type' => 'success', 'message' => 'Task created successfully.'];
+                break;
+
+            case 'update':
+                $id = (int) ($_POST['id'] ?? 0);
+                $title = trim($_POST['title'] ?? '');
+                $description = trim($_POST['description'] ?? '');
+                $dueDate = $_POST['due_date'] !== '' ? $_POST['due_date'] : null;
+                $status = $_POST['status'] ?? 'pending';
+
+                if ($id <= 0 || $title === '' || $description === '') {
+                    throw new InvalidArgumentException('All fields are required for updating a task.');
+                }
+
+                updateTask($id, $title, $description, $dueDate, $status === 'completed' ? 'completed' : 'pending');
+                $_SESSION['flash'] = ['type' => 'success', 'message' => 'Task updated successfully.'];
+                break;
+
+            case 'delete':
+                $id = (int) ($_POST['id'] ?? 0);
+                if ($id <= 0) {
+                    throw new InvalidArgumentException('Invalid task selected for deletion.');
+                }
+
+                deleteTask($id);
+                $_SESSION['flash'] = ['type' => 'success', 'message' => 'Task deleted successfully.'];
+                break;
+
+            case 'toggle':
+                $id = (int) ($_POST['id'] ?? 0);
+                if ($id <= 0) {
+                    throw new InvalidArgumentException('Invalid task selected for update.');
+                }
+
+                toggleTaskStatus($id);
+                $_SESSION['flash'] = ['type' => 'success', 'message' => 'Task status updated.'];
+                break;
+
+            default:
+                throw new InvalidArgumentException('Unknown action requested.');
+        }
+    } catch (Throwable $exception) {
+        $_SESSION['flash'] = ['type' => 'danger', 'message' => $exception->getMessage()];
+    }
+
+    header('Location: ' . $_SERVER['PHP_SELF']);
+    exit;
+}
+
+$tasks = fetchTasks();
+$counts = taskCountsByStatus();
+$flash = $_SESSION['flash'] ?? null;
+unset($_SESSION['flash']);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Todo App</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-9usAa6m8y+Vd2r1dT1dQYxYDs2WdGEylZm4+c2R/g+kPgX9nuSUXGKmEcg2YkdE+5EYXPL3x4lrFZ9+fkDaog==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+    <div class="container">
+        <a class="navbar-brand" href="index.php"><i class="fa-solid fa-list-check me-2"></i>Todo App</a>
+        <div class="d-flex">
+            <a class="btn btn-outline-light" href="admin/login.php"><i class="fa-solid fa-user-shield me-1"></i>Admin</a>
+        </div>
+    </div>
+</nav>
+
+<div class="container">
+    <?php if ($flash): ?>
+        <div class="alert alert-<?= htmlspecialchars($flash['type'], ENT_QUOTES, 'UTF-8') ?> alert-dismissible fade show" role="alert">
+            <?= htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8') ?>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    <?php endif; ?>
+
+    <div class="row g-4 mb-4">
+        <div class="col-md-4">
+            <div class="card text-center shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title text-muted">Total Tasks</h5>
+                    <p class="display-6 mb-0"><?= count($tasks) ?></p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card text-center shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title text-muted">Pending</h5>
+                    <p class="display-6 text-warning mb-0"><?= $counts['pending'] ?></p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card text-center shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title text-muted">Completed</h5>
+                    <p class="display-6 text-success mb-0"><?= $counts['completed'] ?></p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="h4 mb-0">Tasks</h2>
+        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createTaskModal"><i class="fa-solid fa-plus me-2"></i>Add Task</button>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-striped mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th scope="col">Title</th>
+                            <th scope="col">Description</th>
+                            <th scope="col">Due Date</th>
+                            <th scope="col">Status</th>
+                            <th scope="col" class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    <?php if ($tasks): ?>
+                        <?php foreach ($tasks as $task): ?>
+                            <tr data-task='<?= json_encode($task, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?>'>
+                                <td>
+                                    <span class="fw-semibold <?= $task['status'] === 'completed' ? 'text-decoration-line-through text-muted' : '' ?>">
+                                        <?= htmlspecialchars($task['title'], ENT_QUOTES, 'UTF-8') ?>
+                                    </span>
+                                </td>
+                                <td><?= nl2br(htmlspecialchars($task['description'], ENT_QUOTES, 'UTF-8')) ?></td>
+                                <td><?= $task['due_date'] ? htmlspecialchars($task['due_date'], ENT_QUOTES, 'UTF-8') : '—' ?></td>
+                                <td>
+                                    <span class="badge <?= $task['status'] === 'completed' ? 'bg-success' : 'bg-warning text-dark' ?>">
+                                        <?= ucfirst($task['status']) ?>
+                                    </span>
+                                </td>
+                                <td class="text-end">
+                                    <div class="btn-group" role="group">
+                                        <form method="post" class="me-2">
+                                            <input type="hidden" name="action" value="toggle">
+                                            <input type="hidden" name="id" value="<?= (int) $task['id'] ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-secondary">
+                                                <i class="fa-solid fa-rotate"></i>
+                                            </button>
+                                        </form>
+                                        <button class="btn btn-sm btn-outline-primary me-2 btn-edit" data-bs-toggle="modal" data-bs-target="#editTaskModal">
+                                            <i class="fa-solid fa-pen"></i>
+                                        </button>
+                                        <form method="post" onsubmit="return confirm('Are you sure you want to delete this task?');">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="id" value="<?= (int) $task['id'] ?>">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">
+                                                <i class="fa-solid fa-trash"></i>
+                                            </button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php else: ?>
+                        <tr>
+                            <td colspan="5" class="text-center py-4 text-muted">No tasks yet. Use the "Add Task" button to create one.</td>
+                        </tr>
+                    <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Create Task Modal -->
+<div class="modal fade" id="createTaskModal" tabindex="-1" aria-labelledby="createTaskModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form method="post">
+                <input type="hidden" name="action" value="create">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="createTaskModalLabel">Add Task</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="create-title" class="form-label">Title</label>
+                        <input type="text" class="form-control" id="create-title" name="title" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="create-description" class="form-label">Description</label>
+                        <textarea class="form-control" id="create-description" name="description" rows="3" required></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="create-due-date" class="form-label">Due Date</label>
+                        <input type="date" class="form-control" id="create-due-date" name="due_date">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save Task</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- Edit Task Modal -->
+<div class="modal fade" id="editTaskModal" tabindex="-1" aria-labelledby="editTaskModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form method="post" id="edit-task-form">
+                <input type="hidden" name="action" value="update">
+                <input type="hidden" name="id" id="edit-id">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="editTaskModalLabel">Edit Task</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="edit-title" class="form-label">Title</label>
+                        <input type="text" class="form-control" id="edit-title" name="title" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="edit-description" class="form-label">Description</label>
+                        <textarea class="form-control" id="edit-description" name="description" rows="3" required></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="edit-due-date" class="form-label">Due Date</label>
+                        <input type="date" class="form-control" id="edit-due-date" name="due_date">
+                    </div>
+                    <div class="mb-3">
+                        <label for="edit-status" class="form-label">Status</label>
+                        <select class="form-select" id="edit-status" name="status">
+                            <option value="pending">Pending</option>
+                            <option value="completed">Completed</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Update Task</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+    $(function () {
+        $('.btn-edit').on('click', function () {
+            const row = $(this).closest('tr');
+            const data = row.data('task');
+            if (!data) {
+                return;
+            }
+
+            $('#edit-id').val(data.id);
+            $('#edit-title').val(data.title);
+            $('#edit-description').val(data.description);
+            $('#edit-due-date').val(data.due_date);
+            $('#edit-status').val(data.status);
+        });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a Bootstrap-powered public todo interface with task CRUD operations and status tracking
- add an admin dashboard with sample credentials, management modals, and shared task utilities
- provide database schema, configuration, and helper functions for PDO-based persistence

## Testing
- php -l index.php
- php -l functions.php
- php -l config.php
- php -l admin/login.php
- php -l admin/dashboard.php
- php -l admin/logout.php

------
https://chatgpt.com/codex/tasks/task_e_68d8fd2893c08330bce94bcad3e4e635