### PR TITLE
Prevent null values from breaking task edit forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# todoapp7
-todoapp7
+# Todo App
+
+A lightweight task management web application built with PHP, MySQL, Bootstrap 5, and vanilla JavaScript. The app provides both an end-user interface for managing personal tasks and an admin back office for managing users and all tasks across the system.
+
+## Features
+
+- User registration, login, and password management using secure password hashing
+- Personal task dashboard with filtering, creation, editing, and deletion
+- Administrator dashboard with system stats
+- Admin CRUD for users (including admin creation) and all tasks
+- CSRF protection for all POST actions and flash messaging for feedback
+- PDO-based data access with prepared statements
+- Database seed scripts for bootstrapping the environment
+
+## Project Structure
+
+```
+/
+├── admin/              # Admin dashboards and CRUD pages
+├── auth/               # Authentication and password management
+├── config/             # PDO connection setup
+├── helpers/            # Auth, CSRF, and flash helpers
+├── install/            # SQL schema and PHP seeder
+├── partials/           # Shared UI components and guards
+├── public/             # Layout template and static assets
+├── user/               # Authenticated user task management
+└── index.php           # Landing page
+```
+
+## Getting Started
+
+1. Create the database schema and seed data:
+   ```bash
+   mysql -u root -p < install/install.sql
+   ```
+   Or run the PHP seeder after configuring database credentials:
+   ```bash
+   php install/seed.php
+   ```
+2. Configure your web server to serve the project root (e.g., Apache, Nginx, or PHP's built-in server).
+3. Ensure the environment variables `DB_HOST`, `DB_NAME`, `DB_USER`, and `DB_PASS` are set if you need custom connection details. Defaults are `localhost`, `todo_app`, `root`, and an empty password.
+4. Access the application in your browser.
+
+### Default Accounts
+
+- **Admin:** `admin / admin`
+- **User:** `jane / password`
+
+Enjoy managing your tasks!

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_admin.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../public/layout.php';
+
+$totalUsers = $pdo->query('SELECT COUNT(*) AS count FROM users')->fetch()['count'] ?? 0;
+$totalTasks = $pdo->query('SELECT COUNT(*) AS count FROM tasks')->fetch()['count'] ?? 0;
+$statusCountsStmt = $pdo->query("SELECT status, COUNT(*) AS count FROM tasks GROUP BY status");
+$statusCounts = $statusCountsStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+
+render_layout_header('Admin Dashboard');
+?>
+<h1 class="mb-4">Admin Dashboard</h1>
+<?php include __DIR__ . '/../partials/alerts.php'; ?>
+<div class="row g-4">
+    <div class="col-md-4">
+        <div class="card border-primary shadow-sm">
+            <div class="card-body">
+                <h5 class="card-title">Total Users</h5>
+                <p class="display-6 mb-0"><?= htmlspecialchars($totalUsers) ?></p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card border-success shadow-sm">
+            <div class="card-body">
+                <h5 class="card-title">Total Tasks</h5>
+                <p class="display-6 mb-0"><?= htmlspecialchars($totalTasks) ?></p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card border-info shadow-sm">
+            <div class="card-body">
+                <h5 class="card-title">Tasks by Status</h5>
+                <ul class="list-unstyled mb-0">
+                    <li>Pending: <?= htmlspecialchars($statusCounts['pending'] ?? 0) ?></li>
+                    <li>In Progress: <?= htmlspecialchars($statusCounts['in_progress'] ?? 0) ?></li>
+                    <li>Completed: <?= htmlspecialchars($statusCounts['completed'] ?? 0) ?></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+<?php
+render_layout_footer();

--- a/admin/tasks_add.php
+++ b/admin/tasks_add.php
@@ -1,0 +1,99 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_admin.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../helpers/flash.php';
+require_once __DIR__ . '/../public/layout.php';
+
+$userOptions = $pdo->query('SELECT id, username FROM users ORDER BY username ASC')->fetchAll();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $user_id    = (int)($_POST['user_id'] ?? 0);
+    $title      = trim($_POST['title'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $due_date   = $_POST['due_date'] ?? null;
+    $priority   = $_POST['priority'] ?? 'low';
+    $status     = $_POST['status'] ?? 'pending';
+    $csrf_token = $_POST['csrf_token'] ?? null;
+
+    if (!verify_csrf_token($csrf_token)) {
+        set_flash('danger', 'Invalid CSRF token.');
+        redirect('/admin/tasks_add.php');
+    }
+
+    if ($user_id <= 0 || $title === '') {
+        set_flash('danger', 'User and title are required.');
+        redirect('/admin/tasks_add.php');
+    }
+
+    $userCheck = $pdo->prepare('SELECT id FROM users WHERE id = :id');
+    $userCheck->execute([':id' => $user_id]);
+    if (!$userCheck->fetch()) {
+        set_flash('danger', 'Selected user does not exist.');
+        redirect('/admin/tasks_add.php');
+    }
+
+    $stmt = $pdo->prepare('INSERT INTO tasks (user_id, title, description, due_date, priority, status) VALUES (:user_id, :title, :description, :due_date, :priority, :status)');
+    $stmt->execute([
+        ':user_id' => $user_id,
+        ':title' => $title,
+        ':description' => $description !== '' ? $description : null,
+        ':due_date' => $due_date !== '' ? $due_date : null,
+        ':priority' => $priority,
+        ':status' => $status,
+    ]);
+
+    set_flash('success', 'Task created successfully.');
+    redirect('/admin/tasks_list.php');
+}
+
+render_layout_header('Add Task');
+?>
+<h1 class="mb-4">Add Task</h1>
+<?php include __DIR__ . '/../partials/alerts.php'; ?>
+<form method="post" class="card card-body shadow-sm">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+    <div class="mb-3">
+        <label class="form-label" for="user_id">Assign to User</label>
+        <select name="user_id" id="user_id" class="form-select" required>
+            <option value="">Select user</option>
+            <?php foreach ($userOptions as $user): ?>
+                <option value="<?= htmlspecialchars($user['id']) ?>"><?= htmlspecialchars($user['username']) ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="title">Task Title</label>
+        <input type="text" name="title" id="title" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="description">Task Description</label>
+        <textarea name="description" id="description" class="form-control" rows="4"></textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="due_date">Due Date / Deadline</label>
+        <input type="date" name="due_date" id="due_date" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="priority">Priority</label>
+        <select name="priority" id="priority" class="form-select">
+            <option value="low">low</option>
+            <option value="medium">medium</option>
+            <option value="high">high</option>
+        </select>
+    </div>
+    <div class="mb-4">
+        <label class="form-label" for="status">Status</label>
+        <select name="status" id="status" class="form-select">
+            <option value="pending">pending</option>
+            <option value="in_progress">in_progress</option>
+            <option value="completed">completed</option>
+        </select>
+    </div>
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Create Task</button>
+        <a href="/admin/tasks_list.php" class="btn btn-light">Cancel</a>
+    </div>
+</form>
+<?php
+render_layout_footer();

--- a/admin/tasks_delete.php
+++ b/admin/tasks_delete.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_admin.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../helpers/flash.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    redirect('/admin/tasks_list.php');
+}
+
+$csrf_token = $_POST['csrf_token'] ?? null;
+$taskId = (int)($_POST['id'] ?? 0);
+
+if (!verify_csrf_token($csrf_token)) {
+    set_flash('danger', 'Invalid CSRF token.');
+    redirect('/admin/tasks_list.php');
+}
+
+$delete = $pdo->prepare('DELETE FROM tasks WHERE id = :id');
+$delete->execute([':id' => $taskId]);
+
+set_flash('success', 'Task deleted.');
+redirect('/admin/tasks_list.php');

--- a/admin/tasks_edit.php
+++ b/admin/tasks_edit.php
@@ -1,0 +1,110 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_admin.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../helpers/flash.php';
+require_once __DIR__ . '/../public/layout.php';
+
+$taskId = (int)($_GET['id'] ?? $_POST['id'] ?? 0);
+$stmt = $pdo->prepare('SELECT * FROM tasks WHERE id = :id');
+$stmt->execute([':id' => $taskId]);
+$task = $stmt->fetch();
+
+if (!$task) {
+    set_flash('danger', 'Task not found.');
+    redirect('/admin/tasks_list.php');
+}
+
+$userOptions = $pdo->query('SELECT id, username FROM users ORDER BY username ASC')->fetchAll();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $user_id    = (int)($_POST['user_id'] ?? 0);
+    $title      = trim($_POST['title'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $due_date   = $_POST['due_date'] ?? null;
+    $priority   = $_POST['priority'] ?? 'low';
+    $status     = $_POST['status'] ?? 'pending';
+    $csrf_token = $_POST['csrf_token'] ?? null;
+
+    if (!verify_csrf_token($csrf_token)) {
+        set_flash('danger', 'Invalid CSRF token.');
+        redirect('/admin/tasks_edit.php?id=' . urlencode($taskId));
+    }
+
+    if ($user_id <= 0 || $title === '') {
+        set_flash('danger', 'User and title are required.');
+        redirect('/admin/tasks_edit.php?id=' . urlencode($taskId));
+    }
+
+    $userCheck = $pdo->prepare('SELECT id FROM users WHERE id = :id');
+    $userCheck->execute([':id' => $user_id]);
+    if (!$userCheck->fetch()) {
+        set_flash('danger', 'Selected user does not exist.');
+        redirect('/admin/tasks_edit.php?id=' . urlencode($taskId));
+    }
+
+    $update = $pdo->prepare('UPDATE tasks SET user_id = :user_id, title = :title, description = :description, due_date = :due_date, priority = :priority, status = :status WHERE id = :id');
+    $update->execute([
+        ':user_id' => $user_id,
+        ':title' => $title,
+        ':description' => $description !== '' ? $description : null,
+        ':due_date' => $due_date !== '' ? $due_date : null,
+        ':priority' => $priority,
+        ':status' => $status,
+        ':id' => $taskId,
+    ]);
+
+    set_flash('success', 'Task updated successfully.');
+    redirect('/admin/tasks_edit.php?id=' . urlencode($taskId));
+}
+
+render_layout_header('Edit Task');
+?>
+<h1 class="mb-4">Edit Task</h1>
+<?php include __DIR__ . '/../partials/alerts.php'; ?>
+<form method="post" class="card card-body shadow-sm">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+    <input type="hidden" name="id" value="<?= htmlspecialchars($task['id']) ?>">
+    <div class="mb-3">
+        <label class="form-label" for="user_id">Assign to User</label>
+        <select name="user_id" id="user_id" class="form-select" required>
+            <?php foreach ($userOptions as $user): ?>
+                <option value="<?= htmlspecialchars($user['id']) ?>" <?= (int)$user['id'] === (int)$task['user_id'] ? 'selected' : '' ?>><?= htmlspecialchars($user['username']) ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="title">Task Title</label>
+        <input type="text" name="title" id="title" class="form-control" required value="<?= htmlspecialchars($task['title']) ?>">
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="description">Task Description</label>
+        <textarea name="description" id="description" class="form-control" rows="4"><?= htmlspecialchars($_POST['description'] ?? ($task['description'] ?? '')) ?></textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="due_date">Due Date / Deadline</label>
+        <input type="date" name="due_date" id="due_date" class="form-control" value="<?= htmlspecialchars($_POST['due_date'] ?? ($task['due_date'] ?? '')) ?>">
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="priority">Priority</label>
+        <select name="priority" id="priority" class="form-select">
+            <option value="low" <?= $task['priority'] === 'low' ? 'selected' : '' ?>>low</option>
+            <option value="medium" <?= $task['priority'] === 'medium' ? 'selected' : '' ?>>medium</option>
+            <option value="high" <?= $task['priority'] === 'high' ? 'selected' : '' ?>>high</option>
+        </select>
+    </div>
+    <div class="mb-4">
+        <label class="form-label" for="status">Status</label>
+        <select name="status" id="status" class="form-select">
+            <option value="pending" <?= $task['status'] === 'pending' ? 'selected' : '' ?>>pending</option>
+            <option value="in_progress" <?= $task['status'] === 'in_progress' ? 'selected' : '' ?>>in_progress</option>
+            <option value="completed" <?= $task['status'] === 'completed' ? 'selected' : '' ?>>completed</option>
+        </select>
+    </div>
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Update Task</button>
+        <a href="/admin/tasks_list.php" class="btn btn-light">Back to list</a>
+    </div>
+</form>
+<?php
+render_layout_footer();

--- a/admin/tasks_list.php
+++ b/admin/tasks_list.php
@@ -1,0 +1,114 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_admin.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../public/layout.php';
+
+$statusFilter = $_GET['status'] ?? '';
+$priorityFilter = $_GET['priority'] ?? '';
+$userFilter = $_GET['user'] ?? '';
+
+$query = 'SELECT tasks.*, users.username FROM tasks JOIN users ON tasks.user_id = users.id WHERE 1=1';
+$params = [];
+
+if ($statusFilter !== '') {
+    $query .= ' AND tasks.status = :status';
+    $params[':status'] = $statusFilter;
+}
+
+if ($priorityFilter !== '') {
+    $query .= ' AND tasks.priority = :priority';
+    $params[':priority'] = $priorityFilter;
+}
+
+if ($userFilter !== '') {
+    $query .= ' AND tasks.user_id = :user_id';
+    $params[':user_id'] = (int)$userFilter;
+}
+
+$query .= ' ORDER BY tasks.due_date IS NULL, tasks.due_date ASC, tasks.created_at DESC';
+$stmt = $pdo->prepare($query);
+$stmt->execute($params);
+$tasks = $stmt->fetchAll();
+
+$userOptions = $pdo->query('SELECT id, username FROM users ORDER BY username ASC')->fetchAll();
+
+render_layout_header('Manage Tasks');
+?>
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="h3">All Tasks</h1>
+    <a href="/admin/tasks_add.php" class="btn btn-primary">Add Task</a>
+</div>
+<?php include __DIR__ . '/../partials/alerts.php'; ?>
+<form method="get" class="row g-2 mb-4">
+    <div class="col-md-3">
+        <label class="form-label">User</label>
+        <select name="user" class="form-select">
+            <option value="">All Users</option>
+            <?php foreach ($userOptions as $user): ?>
+                <option value="<?= htmlspecialchars($user['id']) ?>" <?= (string)$user['id'] === $userFilter ? 'selected' : '' ?>><?= htmlspecialchars($user['username']) ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">Status</label>
+        <select name="status" class="form-select">
+            <option value="">All</option>
+            <option value="pending" <?= $statusFilter === 'pending' ? 'selected' : '' ?>>Pending</option>
+            <option value="in_progress" <?= $statusFilter === 'in_progress' ? 'selected' : '' ?>>In Progress</option>
+            <option value="completed" <?= $statusFilter === 'completed' ? 'selected' : '' ?>>Completed</option>
+        </select>
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">Priority</label>
+        <select name="priority" class="form-select">
+            <option value="">All</option>
+            <option value="low" <?= $priorityFilter === 'low' ? 'selected' : '' ?>>Low</option>
+            <option value="medium" <?= $priorityFilter === 'medium' ? 'selected' : '' ?>>Medium</option>
+            <option value="high" <?= $priorityFilter === 'high' ? 'selected' : '' ?>>High</option>
+        </select>
+    </div>
+    <div class="col-md-3 d-flex align-items-end">
+        <button type="submit" class="btn btn-outline-secondary me-2">Filter</button>
+        <a href="/admin/tasks_list.php" class="btn btn-light">Reset</a>
+    </div>
+</form>
+<div class="table-responsive">
+    <table class="table table-striped align-middle">
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>User</th>
+                <th>Due Date</th>
+                <th>Priority</th>
+                <th>Status</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (empty($tasks)): ?>
+                <tr><td colspan="6" class="text-center">No tasks found.</td></tr>
+            <?php else: ?>
+                <?php foreach ($tasks as $task): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($task['title']) ?></td>
+                        <td><?= htmlspecialchars($task['username']) ?></td>
+                        <td><?= htmlspecialchars($task['due_date'] ?? '—') ?></td>
+                        <td class="text-capitalize"><?= htmlspecialchars($task['priority']) ?></td>
+                        <td class="text-capitalize"><?= htmlspecialchars(str_replace('_', ' ', $task['status'])) ?></td>
+                        <td>
+                            <a href="/admin/tasks_edit.php?id=<?= urlencode($task['id']) ?>" class="btn btn-sm btn-outline-primary">Edit</a>
+                            <form action="/admin/tasks_delete.php" method="post" class="d-inline" onsubmit="return confirm('Delete this task?');">
+                                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+                                <input type="hidden" name="id" value="<?= htmlspecialchars($task['id']) ?>">
+                                <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                            </form>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </tbody>
+    </table>
+</div>
+<?php
+render_layout_footer();

--- a/admin/users_add.php
+++ b/admin/users_add.php
@@ -1,0 +1,96 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_admin.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../helpers/flash.php';
+require_once __DIR__ . '/../public/layout.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username   = trim($_POST['username'] ?? '');
+    $email      = trim($_POST['email'] ?? '');
+    $role       = $_POST['role'] ?? 'user';
+    $password   = $_POST['password'] ?? '';
+    $confirm    = $_POST['confirm_password'] ?? '';
+    $csrf_token = $_POST['csrf_token'] ?? null;
+
+    if (!verify_csrf_token($csrf_token)) {
+        set_flash('danger', 'Invalid CSRF token.');
+        redirect('/admin/users_add.php');
+    }
+
+    if ($username === '' || $email === '' || $password === '' || $confirm === '') {
+        set_flash('danger', 'All fields are required.');
+        redirect('/admin/users_add.php');
+    }
+
+    if (!in_array($role, ['user', 'admin'], true)) {
+        set_flash('danger', 'Invalid role selected.');
+        redirect('/admin/users_add.php');
+    }
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        set_flash('danger', 'Invalid email address.');
+        redirect('/admin/users_add.php');
+    }
+
+    if ($password !== $confirm) {
+        set_flash('danger', 'Passwords do not match.');
+        redirect('/admin/users_add.php');
+    }
+
+    $stmt = $pdo->prepare('SELECT id FROM users WHERE username = :username OR email = :email LIMIT 1');
+    $stmt->execute([':username' => $username, ':email' => $email]);
+    if ($stmt->fetch()) {
+        set_flash('danger', 'Username or email already in use.');
+        redirect('/admin/users_add.php');
+    }
+
+    $hash = password_hash($password, PASSWORD_DEFAULT);
+    $insert = $pdo->prepare('INSERT INTO users (username, email, password, role) VALUES (:username, :email, :password, :role)');
+    $insert->execute([
+        ':username' => $username,
+        ':email' => $email,
+        ':password' => $hash,
+        ':role' => $role,
+    ]);
+
+    set_flash('success', 'User created successfully.');
+    redirect('/admin/users_list.php');
+}
+
+render_layout_header('Add User');
+?>
+<h1 class="mb-4">Add User</h1>
+<?php include __DIR__ . '/../partials/alerts.php'; ?>
+<form method="post" class="card card-body shadow-sm">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+    <div class="mb-3">
+        <label class="form-label" for="username">Username</label>
+        <input type="text" class="form-control" name="username" id="username" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="email">Email</label>
+        <input type="email" class="form-control" name="email" id="email" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="role">Role</label>
+        <select name="role" id="role" class="form-select">
+            <option value="user">User</option>
+            <option value="admin">Admin</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="password">Temporary Password</label>
+        <input type="password" class="form-control" name="password" id="password" required>
+    </div>
+    <div class="mb-4">
+        <label class="form-label" for="confirm_password">Confirm Password</label>
+        <input type="password" class="form-control" name="confirm_password" id="confirm_password" required>
+    </div>
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Create User</button>
+        <a href="/admin/users_list.php" class="btn btn-light">Cancel</a>
+    </div>
+</form>
+<?php
+render_layout_footer();

--- a/admin/users_delete.php
+++ b/admin/users_delete.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_admin.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../helpers/flash.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    redirect('/admin/users_list.php');
+}
+
+$csrf_token = $_POST['csrf_token'] ?? null;
+$userId = (int)($_POST['id'] ?? 0);
+
+if (!verify_csrf_token($csrf_token)) {
+    set_flash('danger', 'Invalid CSRF token.');
+    redirect('/admin/users_list.php');
+}
+
+if ($userId === $_SESSION['user_id']) {
+    set_flash('danger', 'You cannot delete your own account.');
+    redirect('/admin/users_list.php');
+}
+
+$delete = $pdo->prepare('DELETE FROM users WHERE id = :id');
+$delete->execute([':id' => $userId]);
+
+set_flash('success', 'User deleted.');
+redirect('/admin/users_list.php');

--- a/admin/users_edit.php
+++ b/admin/users_edit.php
@@ -1,0 +1,118 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_admin.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../helpers/flash.php';
+require_once __DIR__ . '/../public/layout.php';
+
+$userId = (int)($_GET['id'] ?? $_POST['id'] ?? 0);
+$stmt = $pdo->prepare('SELECT * FROM users WHERE id = :id');
+$stmt->execute([':id' => $userId]);
+$user = $stmt->fetch();
+
+if (!$user) {
+    set_flash('danger', 'User not found.');
+    redirect('/admin/users_list.php');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username   = trim($_POST['username'] ?? '');
+    $email      = trim($_POST['email'] ?? '');
+    $role       = $_POST['role'] ?? 'user';
+    $password   = $_POST['password'] ?? '';
+    $confirm    = $_POST['confirm_password'] ?? '';
+    $csrf_token = $_POST['csrf_token'] ?? null;
+
+    if (!verify_csrf_token($csrf_token)) {
+        set_flash('danger', 'Invalid CSRF token.');
+        redirect('/admin/users_edit.php?id=' . urlencode($userId));
+    }
+
+    if ($username === '' || $email === '') {
+        set_flash('danger', 'Username and email are required.');
+        redirect('/admin/users_edit.php?id=' . urlencode($userId));
+    }
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        set_flash('danger', 'Invalid email address.');
+        redirect('/admin/users_edit.php?id=' . urlencode($userId));
+    }
+
+    if (!in_array($role, ['user', 'admin'], true)) {
+        set_flash('danger', 'Invalid role selected.');
+        redirect('/admin/users_edit.php?id=' . urlencode($userId));
+    }
+
+    $check = $pdo->prepare('SELECT id FROM users WHERE (username = :username OR email = :email) AND id != :id LIMIT 1');
+    $check->execute([':username' => $username, ':email' => $email, ':id' => $userId]);
+    if ($check->fetch()) {
+        set_flash('danger', 'Username or email already in use by another account.');
+        redirect('/admin/users_edit.php?id=' . urlencode($userId));
+    }
+
+    $pdo->beginTransaction();
+    try {
+        $update = $pdo->prepare('UPDATE users SET username = :username, email = :email, role = :role WHERE id = :id');
+        $update->execute([
+            ':username' => $username,
+            ':email' => $email,
+            ':role' => $role,
+            ':id' => $userId,
+        ]);
+
+        if ($password !== '') {
+            if ($password !== $confirm) {
+                throw new RuntimeException('Passwords do not match.');
+            }
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            $passStmt = $pdo->prepare('UPDATE users SET password = :password WHERE id = :id');
+            $passStmt->execute([':password' => $hash, ':id' => $userId]);
+        }
+
+        $pdo->commit();
+        set_flash('success', 'User updated successfully.');
+    } catch (Throwable $e) {
+        $pdo->rollBack();
+        set_flash('danger', $e->getMessage());
+    }
+
+    redirect('/admin/users_edit.php?id=' . urlencode($userId));
+}
+
+render_layout_header('Edit User');
+?>
+<h1 class="mb-4">Edit User</h1>
+<?php include __DIR__ . '/../partials/alerts.php'; ?>
+<form method="post" class="card card-body shadow-sm">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+    <input type="hidden" name="id" value="<?= htmlspecialchars($user['id']) ?>">
+    <div class="mb-3">
+        <label class="form-label" for="username">Username</label>
+        <input type="text" class="form-control" name="username" id="username" required value="<?= htmlspecialchars($user['username']) ?>">
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="email">Email</label>
+        <input type="email" class="form-control" name="email" id="email" required value="<?= htmlspecialchars($user['email']) ?>">
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="role">Role</label>
+        <select name="role" id="role" class="form-select">
+            <option value="user" <?= $user['role'] === 'user' ? 'selected' : '' ?>>User</option>
+            <option value="admin" <?= $user['role'] === 'admin' ? 'selected' : '' ?>>Admin</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="password">Reset Password (optional)</label>
+        <input type="password" class="form-control" name="password" id="password">
+    </div>
+    <div class="mb-4">
+        <label class="form-label" for="confirm_password">Confirm New Password</label>
+        <input type="password" class="form-control" name="confirm_password" id="confirm_password">
+    </div>
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Update User</button>
+        <a href="/admin/users_list.php" class="btn btn-light">Back to list</a>
+    </div>
+</form>
+<?php
+render_layout_footer();

--- a/admin/users_list.php
+++ b/admin/users_list.php
@@ -1,0 +1,107 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_admin.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../public/layout.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+
+$search = trim($_GET['q'] ?? '');
+$page = max(1, (int)($_GET['page'] ?? 1));
+$perPage = 10;
+$offset = ($page - 1) * $perPage;
+
+$where = '';
+$params = [];
+if ($search !== '') {
+    $where = 'WHERE username LIKE :search OR email LIKE :search';
+    $params[':search'] = '%' . $search . '%';
+}
+
+$countStmt = $pdo->prepare('SELECT COUNT(*) FROM users ' . $where);
+$countStmt->execute($params);
+$total = (int)$countStmt->fetchColumn();
+$totalPages = max(1, (int)ceil($total / $perPage));
+
+$listStmt = $pdo->prepare('SELECT * FROM users ' . $where . ' ORDER BY created_at DESC LIMIT :limit OFFSET :offset');
+foreach ($params as $key => $value) {
+    $listStmt->bindValue($key, $value, PDO::PARAM_STR);
+}
+$listStmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
+$listStmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+$listStmt->execute();
+$users = $listStmt->fetchAll();
+
+render_layout_header('Manage Users');
+?>
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="h3">Users</h1>
+    <a href="/admin/users_add.php" class="btn btn-primary">Add User</a>
+</div>
+<?php include __DIR__ . '/../partials/alerts.php'; ?>
+<form method="get" class="row g-2 mb-4">
+    <div class="col-md-6">
+        <input type="text" name="q" class="form-control" placeholder="Search by username or email" value="<?= htmlspecialchars($search) ?>">
+    </div>
+    <div class="col-md-2">
+        <button type="submit" class="btn btn-outline-secondary">Search</button>
+    </div>
+    <?php if ($search !== ''): ?>
+        <div class="col-md-2">
+            <a href="/admin/users_list.php" class="btn btn-light">Clear</a>
+        </div>
+    <?php endif; ?>
+</form>
+<div class="table-responsive">
+    <table class="table table-hover align-middle">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Username</th>
+                <th>Email</th>
+                <th>Role</th>
+                <th>Created</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (empty($users)): ?>
+                <tr><td colspan="6" class="text-center">No users found.</td></tr>
+            <?php else: ?>
+                <?php foreach ($users as $user): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($user['id']) ?></td>
+                        <td><?= htmlspecialchars($user['username']) ?></td>
+                        <td><?= htmlspecialchars($user['email']) ?></td>
+                        <td class="text-capitalize"><?= htmlspecialchars($user['role']) ?></td>
+                        <td><?= htmlspecialchars($user['created_at']) ?></td>
+                        <td>
+                            <a href="/admin/users_edit.php?id=<?= urlencode($user['id']) ?>" class="btn btn-sm btn-outline-primary">Edit</a>
+                            <?php if ($user['id'] !== $_SESSION['user_id']): ?>
+                                <form action="/admin/users_delete.php" method="post" class="d-inline" onsubmit="return confirm('Delete this user?');">
+                                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+                                    <input type="hidden" name="id" value="<?= htmlspecialchars($user['id']) ?>">
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                </form>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </tbody>
+    </table>
+</div>
+<nav>
+    <ul class="pagination">
+        <?php for ($i = 1; $i <= $totalPages; $i++): ?>
+            <?php
+                $queryParams = $_GET;
+                $queryParams['page'] = $i;
+                $url = '/admin/users_list.php?' . http_build_query($queryParams);
+            ?>
+            <li class="page-item <?= $i === $page ? 'active' : '' ?>">
+                <a class="page-link" href="<?= htmlspecialchars($url) ?>"><?= $i ?></a>
+            </li>
+        <?php endfor; ?>
+    </ul>
+</nav>
+<?php
+render_layout_footer();

--- a/auth/change_password.php
+++ b/auth/change_password.php
@@ -1,0 +1,72 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_login.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../helpers/flash.php';
+require_once __DIR__ . '/../public/layout.php';
+
+$userId = current_user_id();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $current    = $_POST['current_password'] ?? '';
+    $new        = $_POST['new_password'] ?? '';
+    $confirm    = $_POST['confirm_new_password'] ?? '';
+    $csrf_token = $_POST['csrf_token'] ?? null;
+
+    if (!verify_csrf_token($csrf_token)) {
+        set_flash('danger', 'Invalid CSRF token. Please try again.');
+        redirect('/auth/change_password.php');
+    }
+
+    if ($current === '' || $new === '' || $confirm === '') {
+        set_flash('danger', 'All fields are required.');
+        redirect('/auth/change_password.php');
+    }
+
+    if ($new !== $confirm) {
+        set_flash('danger', 'New passwords do not match.');
+        redirect('/auth/change_password.php');
+    }
+
+    $stmt = $pdo->prepare('SELECT password FROM users WHERE id = :id LIMIT 1');
+    $stmt->execute([':id' => $userId]);
+    $user = $stmt->fetch();
+
+    if (!$user || !password_verify($current, $user['password'])) {
+        set_flash('danger', 'Current password is incorrect.');
+        redirect('/auth/change_password.php');
+    }
+
+    $hash = password_hash($new, PASSWORD_DEFAULT);
+    $update = $pdo->prepare('UPDATE users SET password = :password WHERE id = :id');
+    $update->execute([':password' => $hash, ':id' => $userId]);
+
+    set_flash('success', 'Password updated successfully.');
+    if (is_admin()) {
+        redirect('/admin/dashboard.php');
+    }
+    redirect('/user/dashboard.php');
+}
+
+render_layout_header('Change Password');
+?>
+<h1 class="mb-4">Change Password</h1>
+<?php include __DIR__ . '/../partials/alerts.php'; ?>
+<form method="post" class="card card-body shadow-sm">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+    <div class="mb-3">
+        <label for="current_password" class="form-label">Current Password</label>
+        <input type="password" name="current_password" id="current_password" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label for="new_password" class="form-label">New Password</label>
+        <input type="password" name="new_password" id="new_password" class="form-control" required>
+    </div>
+    <div class="mb-4">
+        <label for="confirm_new_password" class="form-label">Confirm New Password</label>
+        <input type="password" name="confirm_new_password" id="confirm_new_password" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Update Password</button>
+</form>
+<?php
+render_layout_footer();

--- a/auth/login.php
+++ b/auth/login.php
@@ -1,0 +1,69 @@
+<?php
+session_start();
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/flash.php';
+require_once __DIR__ . '/../helpers/auth.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../public/layout.php';
+
+if (isset($_SESSION['user_id'])) {
+    if ($_SESSION['role'] === 'admin') {
+        redirect('/admin/dashboard.php');
+    }
+    redirect('/user/dashboard.php');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $identifier = trim($_POST['identifier'] ?? '');
+    $password   = $_POST['password'] ?? '';
+    $csrf_token = $_POST['csrf_token'] ?? null;
+
+    if (!verify_csrf_token($csrf_token)) {
+        set_flash('danger', 'Invalid CSRF token. Please try again.');
+        redirect('/auth/login.php');
+    }
+
+    if ($identifier === '' || $password === '') {
+        set_flash('danger', 'Please provide your username/email and password.');
+        redirect('/auth/login.php');
+    }
+
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE username = :identifier OR email = :identifier LIMIT 1');
+    $stmt->execute([':identifier' => $identifier]);
+    $user = $stmt->fetch();
+
+    if ($user && password_verify($password, $user['password'])) {
+        session_regenerate_id(true);
+        $_SESSION['user_id'] = (int)$user['id'];
+        $_SESSION['username'] = $user['username'];
+        $_SESSION['role'] = $user['role'];
+        set_flash('success', 'Welcome back, ' . $user['username'] . '!');
+        if ($user['role'] === 'admin') {
+            redirect('/admin/dashboard.php');
+        }
+        redirect('/user/dashboard.php');
+    }
+
+    set_flash('danger', 'Invalid credentials.');
+    redirect('/auth/login.php');
+}
+
+render_layout_header('Login');
+include __DIR__ . '/../partials/alerts.php';
+?>
+<h1 class="mb-4">Login</h1>
+<form method="post" class="card card-body shadow-sm">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+    <div class="mb-3">
+        <label for="identifier" class="form-label">Username or Email</label>
+        <input type="text" name="identifier" id="identifier" class="form-control" required>
+    </div>
+    <div class="mb-4">
+        <label for="password" class="form-label">Password</label>
+        <input type="password" name="password" id="password" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+    <p class="mt-3 mb-0">Don't have an account? <a href="/auth/register.php">Register here</a>.</p>
+</form>
+<?php
+render_layout_footer();

--- a/auth/logout.php
+++ b/auth/logout.php
@@ -1,0 +1,18 @@
+<?php
+session_start();
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../helpers/flash.php';
+require_once __DIR__ . '/../helpers/auth.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $csrf_token = $_POST['csrf_token'] ?? null;
+    if (!verify_csrf_token($csrf_token)) {
+        set_flash('danger', 'Invalid CSRF token.');
+        redirect('/auth/login.php');
+    }
+}
+
+$_SESSION = [];
+session_destroy();
+set_flash('success', 'You have been logged out.');
+redirect('/auth/login.php');

--- a/auth/register.php
+++ b/auth/register.php
@@ -1,0 +1,93 @@
+<?php
+session_start();
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/flash.php';
+require_once __DIR__ . '/../helpers/auth.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../public/layout.php';
+
+if (isset($_SESSION['user_id'])) {
+    if ($_SESSION['role'] === 'admin') {
+        redirect('/admin/dashboard.php');
+    }
+    redirect('/user/dashboard.php');
+}
+
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username   = trim($_POST['username'] ?? '');
+    $email      = trim($_POST['email'] ?? '');
+    $password   = $_POST['password'] ?? '';
+    $confirm    = $_POST['confirm_password'] ?? '';
+    $csrf_token = $_POST['csrf_token'] ?? null;
+
+    if (!verify_csrf_token($csrf_token)) {
+        $errors[] = 'Invalid CSRF token. Please try again.';
+    }
+
+    if ($username === '' || $email === '' || $password === '' || $confirm === '') {
+        $errors[] = 'All fields are required.';
+    }
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Please enter a valid email address.';
+    }
+
+    if ($password !== $confirm) {
+        $errors[] = 'Passwords do not match.';
+    }
+
+    if (empty($errors)) {
+        $stmt = $pdo->prepare('SELECT id FROM users WHERE username = :username OR email = :email LIMIT 1');
+        $stmt->execute([':username' => $username, ':email' => $email]);
+        if ($stmt->fetch()) {
+            $errors[] = 'Username or email already in use.';
+        }
+    }
+
+    if (empty($errors)) {
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $stmt = $pdo->prepare('INSERT INTO users (username, email, password, role) VALUES (:username, :email, :password, "user")');
+        $stmt->execute([
+            ':username' => $username,
+            ':email' => $email,
+            ':password' => $hash,
+        ]);
+
+        set_flash('success', 'Registration successful. Please login.');
+        redirect('/auth/login.php');
+    } else {
+        foreach ($errors as $error) {
+            set_flash('danger', $error);
+        }
+    }
+}
+
+render_layout_header('Register');
+include __DIR__ . '/../partials/alerts.php';
+?>
+<h1 class="mb-4">Create an account</h1>
+<form method="post" class="card card-body shadow-sm">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+    <div class="mb-3">
+        <label for="username" class="form-label">Username</label>
+        <input type="text" name="username" id="username" class="form-control" required value="<?= htmlspecialchars($_POST['username'] ?? '') ?>">
+    </div>
+    <div class="mb-3">
+        <label for="email" class="form-label">Email</label>
+        <input type="email" name="email" id="email" class="form-control" required value="<?= htmlspecialchars($_POST['email'] ?? '') ?>">
+    </div>
+    <div class="mb-3">
+        <label for="password" class="form-label">Password</label>
+        <input type="password" name="password" id="password" class="form-control" required>
+    </div>
+    <div class="mb-4">
+        <label for="confirm_password" class="form-label">Confirm Password</label>
+        <input type="password" name="confirm_password" id="confirm_password" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Register</button>
+    <p class="mt-3 mb-0">Already have an account? <a href="/auth/login.php">Login here</a>.</p>
+</form>
+<?php
+render_layout_footer();

--- a/config/db.php
+++ b/config/db.php
@@ -1,0 +1,17 @@
+<?php
+// Database configuration and PDO initialization
+$host = getenv('DB_HOST') ?: 'localhost';
+$db   = getenv('DB_NAME') ?: 'todo_app';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: '';
+$dsn  = "mysql:host={$host};dbname={$db};charset=utf8mb4";
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ]);
+} catch (PDOException $e) {
+    die('Database connection failed: ' . htmlspecialchars($e->getMessage()));
+}

--- a/helpers/auth.php
+++ b/helpers/auth.php
@@ -1,0 +1,39 @@
+<?php
+// Authentication helper functions
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+/**
+ * Determine if a user is currently logged in.
+ */
+function is_logged_in(): bool
+{
+    return isset($_SESSION['user_id']);
+}
+
+/**
+ * Determine if the current user is an administrator.
+ */
+function is_admin(): bool
+{
+    return isset($_SESSION['role']) && $_SESSION['role'] === 'admin';
+}
+
+/**
+ * Retrieve the current user ID.
+ */
+function current_user_id(): ?int
+{
+    return $_SESSION['user_id'] ?? null;
+}
+
+/**
+ * Redirect helper that terminates script execution after sending headers.
+ */
+function redirect(string $path): void
+{
+    header('Location: ' . $path);
+    exit;
+}

--- a/helpers/csrf.php
+++ b/helpers/csrf.php
@@ -1,0 +1,22 @@
+<?php
+// CSRF token generation and validation helpers
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+function generate_csrf_token(): string
+{
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function verify_csrf_token(?string $token): bool
+{
+    if (empty($_SESSION['csrf_token']) || empty($token)) {
+        return false;
+    }
+    return hash_equals($_SESSION['csrf_token'], $token);
+}

--- a/helpers/flash.php
+++ b/helpers/flash.php
@@ -1,0 +1,18 @@
+<?php
+// Flash message helper utilities
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+function set_flash(string $type, string $message): void
+{
+    $_SESSION['flash'][$type][] = $message;
+}
+
+function get_flash(): array
+{
+    $messages = $_SESSION['flash'] ?? [];
+    unset($_SESSION['flash']);
+    return $messages;
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,28 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+require_once __DIR__ . '/helpers/auth.php';
+
+if (is_logged_in()) {
+    if (is_admin()) {
+        redirect('/admin/dashboard.php');
+    }
+    redirect('/user/dashboard.php');
+}
+
+require_once __DIR__ . '/public/layout.php';
+render_layout_header('Welcome to Todo App');
+include __DIR__ . '/partials/alerts.php';
+?>
+
+<div class="text-center py-5">
+    <h1 class="display-5 fw-bold mb-3">Welcome to the Todo App</h1>
+    <p class="lead mb-4">Manage your tasks efficiently and stay organized.</p>
+    <div class="d-flex justify-content-center gap-3">
+        <a href="/auth/login.php" class="btn btn-primary btn-lg">Login</a>
+        <a href="/auth/register.php" class="btn btn-outline-light btn-lg">Register</a>
+    </div>
+</div>
+<?php
+render_layout_footer();

--- a/install/install.sql
+++ b/install/install.sql
@@ -1,0 +1,34 @@
+CREATE DATABASE IF NOT EXISTS todo_app CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE todo_app;
+
+DROP TABLE IF EXISTS tasks;
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) UNIQUE NOT NULL,
+    email VARCHAR(120) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    role ENUM('user','admin') NOT NULL DEFAULT 'user',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE tasks (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NULL,
+    due_date DATE NULL,
+    priority ENUM('low','medium','high') NOT NULL DEFAULT 'low',
+    status ENUM('pending','in_progress','completed') NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_tasks_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO users (username, email, password, role) VALUES
+('admin', 'admin@example.com', '$2y$12$A7vBONxkqrIeNoeydthGLuJVtlD/nhiCHZgWudCejQjsx4XNS47yK', 'admin'),
+('jane', 'jane@example.com', '$2y$12$MrsyVNeCPBfaBySDX2Wv0Oif3eq3vUP8hVyVThqzDR2L6saJUnij6', 'user');
+
+INSERT INTO tasks (user_id, title, description, due_date, priority, status) VALUES
+((SELECT id FROM users WHERE username = 'jane'), 'Buy groceries', 'Milk, eggs, bread, and fruit', DATE_ADD(CURDATE(), INTERVAL 2 DAY), 'medium', 'pending'),
+((SELECT id FROM users WHERE username = 'jane'), 'Prepare presentation', 'Slides for Monday meeting', DATE_ADD(CURDATE(), INTERVAL 5 DAY), 'high', 'in_progress');

--- a/install/seed.php
+++ b/install/seed.php
@@ -1,0 +1,49 @@
+<?php
+require_once __DIR__ . '/../config/db.php';
+
+function ensure_user(PDO $pdo, string $username, string $email, string $password, string $role): int
+{
+    $stmt = $pdo->prepare('SELECT id FROM users WHERE username = :username OR email = :email LIMIT 1');
+    $stmt->execute([':username' => $username, ':email' => $email]);
+    $user = $stmt->fetch();
+    if ($user) {
+        return (int)$user['id'];
+    }
+
+    $hash = password_hash($password, PASSWORD_DEFAULT);
+    $insert = $pdo->prepare('INSERT INTO users (username, email, password, role) VALUES (:username, :email, :password, :role)');
+    $insert->execute([
+        ':username' => $username,
+        ':email' => $email,
+        ':password' => $hash,
+        ':role' => $role,
+    ]);
+    return (int)$pdo->lastInsertId();
+}
+
+$adminId = ensure_user($pdo, 'admin', 'admin@example.com', 'admin', 'admin');
+$userId = ensure_user($pdo, 'jane', 'jane@example.com', 'password', 'user');
+
+$taskCheck = $pdo->prepare('SELECT COUNT(*) FROM tasks WHERE user_id = :user_id');
+$taskCheck->execute([':user_id' => $userId]);
+if ((int)$taskCheck->fetchColumn() === 0) {
+    $taskInsert = $pdo->prepare('INSERT INTO tasks (user_id, title, description, due_date, priority, status) VALUES (:user_id, :title, :description, :due_date, :priority, :status)');
+    $taskInsert->execute([
+        ':user_id' => $userId,
+        ':title' => 'Buy groceries',
+        ':description' => 'Milk, eggs, bread, and fruit',
+        ':due_date' => date('Y-m-d', strtotime('+2 days')),
+        ':priority' => 'medium',
+        ':status' => 'pending',
+    ]);
+    $taskInsert->execute([
+        ':user_id' => $userId,
+        ':title' => 'Prepare presentation',
+        ':description' => 'Slides for Monday meeting',
+        ':due_date' => date('Y-m-d', strtotime('+5 days')),
+        ':priority' => 'high',
+        ':status' => 'in_progress',
+    ]);
+}
+
+echo "Seeding complete. Admin ID: {$adminId}, User ID: {$userId}" . PHP_EOL;

--- a/partials/alerts.php
+++ b/partials/alerts.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/../helpers/flash.php';
+$flashMessages = get_flash();
+?>
+<?php if (!empty($flashMessages)): ?>
+    <?php foreach ($flashMessages as $type => $messages): ?>
+        <?php foreach ($messages as $message): ?>
+            <div class="alert alert-<?= htmlspecialchars($type) ?> alert-dismissible fade show" role="alert">
+                <?= htmlspecialchars($message) ?>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        <?php endforeach; ?>
+    <?php endforeach; ?>
+<?php endif; ?>

--- a/partials/guard/require_admin.php
+++ b/partials/guard/require_admin.php
@@ -1,0 +1,7 @@
+<?php
+require_once __DIR__ . '/require_login.php';
+
+if (!is_admin()) {
+    set_flash('danger', 'Administrator access required.');
+    redirect('/user/dashboard.php');
+}

--- a/partials/guard/require_login.php
+++ b/partials/guard/require_login.php
@@ -1,0 +1,12 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+require_once __DIR__ . '/../../helpers/auth.php';
+require_once __DIR__ . '/../../helpers/flash.php';
+
+if (!is_logged_in()) {
+    set_flash('danger', 'You must be logged in to access that page.');
+    redirect('/auth/login.php');
+}

--- a/public/layout.php
+++ b/public/layout.php
@@ -1,0 +1,70 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+require_once __DIR__ . '/../helpers/auth.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+
+function render_layout_header(string $title = 'Todo App'): void
+{
+    ?>
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title><?= htmlspecialchars($title) ?></title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    </head>
+    <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="/">Todo App</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                    <?php if (is_logged_in() && is_admin()): ?>
+                        <li class="nav-item"><a class="nav-link" href="/admin/dashboard.php">Dashboard</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/admin/users_list.php">Users</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/admin/tasks_list.php">Tasks</a></li>
+                    <?php elseif (is_logged_in()): ?>
+                        <li class="nav-item"><a class="nav-link" href="/user/dashboard.php">My Tasks</a></li>
+                    <?php else: ?>
+                        <li class="nav-item"><a class="nav-link" href="/auth/login.php">Login</a></li>
+                        <li class="nav-item"><a class="nav-link" href="/auth/register.php">Register</a></li>
+                    <?php endif; ?>
+                </ul>
+                <ul class="navbar-nav ms-auto">
+                    <?php if (is_logged_in()): ?>
+                        <li class="nav-item me-3 text-light align-self-center">
+                            Hello, <?= htmlspecialchars($_SESSION['username']) ?> (<?= htmlspecialchars($_SESSION['role']) ?>)
+                        </li>
+                        <li class="nav-item"><a class="nav-link" href="/auth/change_password.php">Change Password</a></li>
+                        <li class="nav-item">
+                            <form action="/auth/logout.php" method="post" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+                                <button class="btn btn-link nav-link" type="submit">Logout</button>
+                            </form>
+                        </li>
+                    <?php endif; ?>
+                </ul>
+            </div>
+        </div>
+    </nav>
+    <main class="py-4">
+        <div class="container">
+    <?php
+}
+
+function render_layout_footer(): void
+{
+    ?>
+        </div>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+    </body>
+    </html>
+    <?php
+}

--- a/user/dashboard.php
+++ b/user/dashboard.php
@@ -1,0 +1,98 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_login.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../public/layout.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+
+$userId = current_user_id();
+$statusFilter = $_GET['status'] ?? '';
+$priorityFilter = $_GET['priority'] ?? '';
+
+$query = 'SELECT * FROM tasks WHERE user_id = :user_id';
+$params = [':user_id' => $userId];
+
+if ($statusFilter !== '') {
+    $query .= ' AND status = :status';
+    $params[':status'] = $statusFilter;
+}
+
+if ($priorityFilter !== '') {
+    $query .= ' AND priority = :priority';
+    $params[':priority'] = $priorityFilter;
+}
+
+$query .= ' ORDER BY due_date IS NULL, due_date ASC, created_at DESC';
+$stmt = $pdo->prepare($query);
+$stmt->execute($params);
+$tasks = $stmt->fetchAll();
+
+render_layout_header('My Tasks');
+?>
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="h3">My Tasks</h1>
+    <a href="/user/tasks_add.php" class="btn btn-primary">Add Task</a>
+</div>
+<?php include __DIR__ . '/../partials/alerts.php'; ?>
+<form method="get" class="row g-2 mb-4">
+    <div class="col-md-4">
+        <label class="form-label">Status</label>
+        <select name="status" class="form-select">
+            <option value="">All</option>
+            <option value="pending" <?= $statusFilter === 'pending' ? 'selected' : '' ?>>Pending</option>
+            <option value="in_progress" <?= $statusFilter === 'in_progress' ? 'selected' : '' ?>>In Progress</option>
+            <option value="completed" <?= $statusFilter === 'completed' ? 'selected' : '' ?>>Completed</option>
+        </select>
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">Priority</label>
+        <select name="priority" class="form-select">
+            <option value="">All</option>
+            <option value="low" <?= $priorityFilter === 'low' ? 'selected' : '' ?>>Low</option>
+            <option value="medium" <?= $priorityFilter === 'medium' ? 'selected' : '' ?>>Medium</option>
+            <option value="high" <?= $priorityFilter === 'high' ? 'selected' : '' ?>>High</option>
+        </select>
+    </div>
+    <div class="col-md-4 d-flex align-items-end">
+        <button type="submit" class="btn btn-outline-secondary me-2">Filter</button>
+        <a href="/user/dashboard.php" class="btn btn-light">Reset</a>
+    </div>
+</form>
+<div class="table-responsive">
+    <table class="table table-striped align-middle">
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>Due Date</th>
+                <th>Priority</th>
+                <th>Status</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (empty($tasks)): ?>
+            <tr>
+                <td colspan="5" class="text-center">No tasks found.</td>
+            </tr>
+        <?php else: ?>
+            <?php foreach ($tasks as $task): ?>
+                <tr>
+                    <td><?= htmlspecialchars($task['title']) ?></td>
+                    <td><?= htmlspecialchars($task['due_date'] ?? '—') ?></td>
+                    <td class="text-capitalize"><?= htmlspecialchars($task['priority']) ?></td>
+                    <td class="text-capitalize"><?= htmlspecialchars(str_replace('_', ' ', $task['status'])) ?></td>
+                    <td>
+                        <a href="/user/tasks_edit.php?id=<?= urlencode($task['id']) ?>" class="btn btn-sm btn-outline-primary">Edit</a>
+                        <form action="/user/tasks_delete.php" method="post" class="d-inline" onsubmit="return confirm('Delete this task?');">
+                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+                            <input type="hidden" name="id" value="<?= htmlspecialchars($task['id']) ?>">
+                            <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</div>
+<?php
+render_layout_footer();

--- a/user/tasks_add.php
+++ b/user/tasks_add.php
@@ -1,0 +1,89 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_login.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../helpers/flash.php';
+require_once __DIR__ . '/../public/layout.php';
+
+$userId = current_user_id();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title       = trim($_POST['title'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $due_date    = $_POST['due_date'] ?? null;
+    $priority    = $_POST['priority'] ?? 'low';
+    $status      = $_POST['status'] ?? 'pending';
+    $user_id     = (int)($_POST['user_id'] ?? 0);
+    $csrf_token  = $_POST['csrf_token'] ?? null;
+
+    if (!verify_csrf_token($csrf_token)) {
+        set_flash('danger', 'Invalid CSRF token. Please try again.');
+        redirect('/user/tasks_add.php');
+    }
+
+    if ($user_id !== $userId) {
+        set_flash('danger', 'Invalid user.');
+        redirect('/user/dashboard.php');
+    }
+
+    if ($title === '') {
+        set_flash('danger', 'Task title is required.');
+        redirect('/user/tasks_add.php');
+    }
+
+    $stmt = $pdo->prepare('INSERT INTO tasks (user_id, title, description, due_date, priority, status) VALUES (:user_id, :title, :description, :due_date, :priority, :status)');
+    $stmt->execute([
+        ':user_id' => $userId,
+        ':title' => $title,
+        ':description' => $description !== '' ? $description : null,
+        ':due_date' => $due_date !== '' ? $due_date : null,
+        ':priority' => $priority,
+        ':status' => $status,
+    ]);
+
+    set_flash('success', 'Task created successfully.');
+    redirect('/user/dashboard.php');
+}
+
+render_layout_header('Add Task');
+?>
+<h1 class="mb-4">Add Task</h1>
+<?php include __DIR__ . '/../partials/alerts.php'; ?>
+<form method="post" class="card card-body shadow-sm">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+    <div class="mb-3">
+        <label class="form-label" for="title">Task Title</label>
+        <input type="text" name="title" id="title" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="description">Task Description</label>
+        <textarea name="description" id="description" class="form-control" rows="4"></textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="due_date">Due Date / Deadline</label>
+        <input type="date" name="due_date" id="due_date" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="priority">Priority</label>
+        <select name="priority" id="priority" class="form-select">
+            <option value="low">low</option>
+            <option value="medium">medium</option>
+            <option value="high">high</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="status">Status</label>
+        <select name="status" id="status" class="form-select">
+            <option value="pending">pending</option>
+            <option value="in_progress">in_progress</option>
+            <option value="completed">completed</option>
+        </select>
+    </div>
+    <input type="hidden" name="user_id" value="<?= htmlspecialchars($userId) ?>">
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Save Task</button>
+        <a href="/user/dashboard.php" class="btn btn-light">Cancel</a>
+    </div>
+</form>
+<?php
+render_layout_footer();

--- a/user/tasks_delete.php
+++ b/user/tasks_delete.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_login.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../helpers/flash.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    redirect('/user/dashboard.php');
+}
+
+$csrf_token = $_POST['csrf_token'] ?? null;
+$taskId = (int)($_POST['id'] ?? 0);
+$userId = current_user_id();
+
+if (!verify_csrf_token($csrf_token)) {
+    set_flash('danger', 'Invalid CSRF token.');
+    redirect('/user/dashboard.php');
+}
+
+$stmt = $pdo->prepare('DELETE FROM tasks WHERE id = :id AND user_id = :user_id');
+$stmt->execute([':id' => $taskId, ':user_id' => $userId]);
+
+set_flash('success', 'Task deleted.');
+redirect('/user/dashboard.php');

--- a/user/tasks_edit.php
+++ b/user/tasks_edit.php
@@ -1,0 +1,95 @@
+<?php
+require_once __DIR__ . '/../partials/guard/require_login.php';
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../helpers/csrf.php';
+require_once __DIR__ . '/../helpers/flash.php';
+require_once __DIR__ . '/../public/layout.php';
+
+$userId = current_user_id();
+$taskId = (int)($_GET['id'] ?? $_POST['id'] ?? 0);
+
+$stmt = $pdo->prepare('SELECT * FROM tasks WHERE id = :id AND user_id = :user_id');
+$stmt->execute([':id' => $taskId, ':user_id' => $userId]);
+$task = $stmt->fetch();
+
+if (!$task) {
+    set_flash('danger', 'Task not found.');
+    redirect('/user/dashboard.php');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title       = trim($_POST['title'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $due_date    = $_POST['due_date'] ?? null;
+    $priority    = $_POST['priority'] ?? 'low';
+    $status      = $_POST['status'] ?? 'pending';
+    $csrf_token  = $_POST['csrf_token'] ?? null;
+
+    if (!verify_csrf_token($csrf_token)) {
+        set_flash('danger', 'Invalid CSRF token.');
+        redirect('/user/tasks_edit.php?id=' . urlencode($taskId));
+    }
+
+    if ($title === '') {
+        set_flash('danger', 'Task title is required.');
+        redirect('/user/tasks_edit.php?id=' . urlencode($taskId));
+    }
+
+    $update = $pdo->prepare('UPDATE tasks SET title = :title, description = :description, due_date = :due_date, priority = :priority, status = :status WHERE id = :id AND user_id = :user_id');
+    $update->execute([
+        ':title' => $title,
+        ':description' => $description !== '' ? $description : null,
+        ':due_date' => $due_date !== '' ? $due_date : null,
+        ':priority' => $priority,
+        ':status' => $status,
+        ':id' => $taskId,
+        ':user_id' => $userId,
+    ]);
+
+    set_flash('success', 'Task updated successfully.');
+    redirect('/user/dashboard.php');
+}
+
+render_layout_header('Edit Task');
+?>
+<h1 class="mb-4">Edit Task</h1>
+<?php include __DIR__ . '/../partials/alerts.php'; ?>
+<form method="post" class="card card-body shadow-sm">
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+    <input type="hidden" name="id" value="<?= htmlspecialchars($task['id']) ?>">
+    <div class="mb-3">
+        <label class="form-label" for="title">Task Title</label>
+        <input type="text" name="title" id="title" class="form-control" required value="<?= htmlspecialchars($task['title']) ?>">
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="description">Task Description</label>
+        <textarea name="description" id="description" class="form-control" rows="4"><?= htmlspecialchars($task['description'] ?? '') ?></textarea>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="due_date">Due Date / Deadline</label>
+        <input type="date" name="due_date" id="due_date" class="form-control" value="<?= htmlspecialchars($_POST['due_date'] ?? ($task['due_date'] ?? '')) ?>">
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="priority">Priority</label>
+        <select name="priority" id="priority" class="form-select">
+            <option value="low" <?= $task['priority'] === 'low' ? 'selected' : '' ?>>low</option>
+            <option value="medium" <?= $task['priority'] === 'medium' ? 'selected' : '' ?>>medium</option>
+            <option value="high" <?= $task['priority'] === 'high' ? 'selected' : '' ?>>high</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label" for="status">Status</label>
+        <select name="status" id="status" class="form-select">
+            <option value="pending" <?= $task['status'] === 'pending' ? 'selected' : '' ?>>pending</option>
+            <option value="in_progress" <?= $task['status'] === 'in_progress' ? 'selected' : '' ?>>in_progress</option>
+            <option value="completed" <?= $task['status'] === 'completed' ? 'selected' : '' ?>>completed</option>
+        </select>
+    </div>
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Update Task</button>
+        <a href="/user/dashboard.php" class="btn btn-light">Cancel</a>
+    </div>
+</form>
+<?php
+render_layout_footer();
+?>


### PR DESCRIPTION
## Summary
- ensure the admin task edit form always passes a string to htmlspecialchars for description and due date inputs
- fall back to the submitted value or an empty string when rendering the user task edit due date field

## Testing
- php -l admin/tasks_edit.php
- php -l user/tasks_edit.php

------
https://chatgpt.com/codex/tasks/task_e_68da16823d4883309a5d79c6eb5f9468