### PR TITLE
feat: build enterprise todo full-stack app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.env
+backend/node_modules
+frontend/node_modules
+.tmp
+build
+coverage
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,80 @@
-# todoapp7
-todoapp7
+# Enterprise Todo Application
+
+This repository contains a full-stack Todo application featuring an AdonisJS v6 backend and a React (Vite) frontend. It demonstrates JWT authentication, role-based access for admins and users, and complete CRUD capabilities for todos.
+
+## Project structure
+
+```
+.
+├── backend   # AdonisJS v6 API
+├── frontend  # React dashboard (Vite)
+└── README.md
+```
+
+## Backend (AdonisJS v6)
+
+### Prerequisites
+
+- Node.js 18+
+- PostgreSQL database using the following defaults (configurable via `.env`):
+  - `PG_HOST=localhost`
+  - `PG_PORT=5432`
+  - `PG_USER=postgres`
+  - `PG_PASSWORD=admin`
+  - `PG_DB_NAME=Docapp3`
+
+### Setup & usage
+
+```bash
+cd backend
+cp .env.example .env
+npm install
+node ace migration:run
+node ace db:seed
+npm run dev
+```
+
+The API will be available at `http://localhost:3333` and provides:
+
+- `POST /register` – Register users (optional role selection)
+- `POST /login` – Obtain a JWT access token
+- Authenticated user routes under `/todos`
+- Admin-only routes under `/admin`
+
+Seeded credentials:
+
+- Admin — `admin@example.com` / `admin123`
+- User — `user@example.com` / `user123`
+
+## Frontend (React + Vite)
+
+### Setup & usage
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Create a `.env` file (optional) to override the API URL:
+
+```
+VITE_API_URL=http://localhost:3333
+```
+
+Routes:
+
+- `/login` – Login page for users and admins
+- `/register` – New user registration
+- `/dashboard` – Authenticated user todo management
+- `/admin` – Admin oversight of users and todos
+
+## Running the full stack
+
+1. Start the backend API (`npm run dev` inside `backend`).
+2. Start the frontend dev server (`npm run dev` inside `frontend`).
+3. Access the UI at `http://localhost:5173`.
+
+## Testing & linting
+
+This starter does not ship with automated tests. Use the provided scripts to run AdonisJS commands or to extend with your preferred testing tools.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,10 @@
+PORT=3333
+HOST=0.0.0.0
+NODE_ENV=development
+APP_KEY=your-secret-app-key
+DRIVE_DISK=local
+PG_HOST=localhost
+PG_PORT=5432
+PG_USER=postgres
+PG_PASSWORD=admin
+PG_DB_NAME=Docapp3

--- a/backend/ace.ts
+++ b/backend/ace.ts
@@ -1,0 +1,8 @@
+import 'reflect-metadata'
+import { Ignitor } from '@adonisjs/core/ignitor'
+import { fileURLToPath } from 'node:url'
+import { dirname } from 'node:path'
+
+const appRoot = dirname(fileURLToPath(import.meta.url))
+
+new Ignitor(appRoot).ace().handle(process.argv.slice(2))

--- a/backend/adonisrc.ts
+++ b/backend/adonisrc.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@adonisjs/core/adonisrc'
+
+export default defineConfig({
+  providers: [
+    () => import('@adonisjs/core/provider'),
+    () => import('@adonisjs/bodyparser/provider'),
+    () => import('@adonisjs/auth/provider'),
+    () => import('@adonisjs/lucid/provider'),
+  ],
+  commands: [() => import('@adonisjs/lucid/commands')],
+  preload: [
+    {
+      file: '#start/kernel',
+    },
+    {
+      file: '#start/routes',
+    },
+  ],
+})

--- a/backend/app/Controllers/Http/AdminController.ts
+++ b/backend/app/Controllers/Http/AdminController.ts
@@ -1,0 +1,83 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { DateTime } from 'luxon'
+import vine from '@vinejs/vine'
+import User from '#models/user'
+import Todo from '#models/todo'
+
+const adminTodoUpdateSchema = vine.compile(
+  vine.object({
+    title: vine.string().trim().minLength(3).optional(),
+    description: vine.string().trim().minLength(3).optional(),
+    priority: vine.enum(['low', 'medium', 'high']).optional(),
+    status: vine.enum(['pending', 'in-progress', 'completed']).optional(),
+    dueDate: vine.date({ formats: ['yyyy-MM-dd'] }).optional().nullable(),
+    userId: vine.number().positive().optional(),
+  })
+)
+
+function parseDueDate(value: unknown): DateTime | null {
+  if (!value) {
+    return null
+  }
+
+  if (value instanceof Date) {
+    return DateTime.fromJSDate(value)
+  }
+
+  if (typeof value === 'string') {
+    const parsed = DateTime.fromISO(value)
+    return parsed.isValid ? parsed : null
+  }
+
+  return null
+}
+
+export default class AdminController {
+  public async users({}: HttpContext) {
+    return User.query().select('id', 'name', 'email', 'role', 'created_at')
+  }
+
+  public async todos({}: HttpContext) {
+    return Todo.query().preload('user', (query) => {
+      query.select('id', 'name', 'email', 'role')
+    })
+  }
+
+  public async updateTodo({ params, request, response }: HttpContext) {
+    const payload = await vine.validate({ schema: adminTodoUpdateSchema, data: request.all() })
+    const todo = await Todo.find(params.id)
+
+    if (!todo) {
+      return response.notFound({ message: 'Todo not found' })
+    }
+
+    if (payload.userId) {
+      todo.userId = payload.userId
+    }
+
+    if (payload.dueDate !== undefined) {
+      todo.dueDate = parseDueDate(payload.dueDate)
+    }
+
+    todo.merge({
+      title: payload.title ?? todo.title,
+      description: payload.description ?? todo.description,
+      priority: payload.priority ?? todo.priority,
+      status: payload.status ?? todo.status,
+    })
+
+    await todo.save()
+    await todo.load('user')
+    return todo
+  }
+
+  public async deleteTodo({ params, response }: HttpContext) {
+    const todo = await Todo.find(params.id)
+    if (!todo) {
+      return response.notFound({ message: 'Todo not found' })
+    }
+
+    await todo.delete()
+    return response.noContent()
+  }
+}

--- a/backend/app/Controllers/Http/AuthController.ts
+++ b/backend/app/Controllers/Http/AuthController.ts
@@ -1,0 +1,70 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import vine from '@vinejs/vine'
+import User from '#models/user'
+
+const registerSchema = vine.compile(
+  vine.object({
+    name: vine.string().trim().minLength(2),
+    email: vine.string().trim().email(),
+    password: vine.string().minLength(6),
+    role: vine.enum(['user', 'admin']).optional(),
+  })
+)
+
+const loginSchema = vine.compile(
+  vine.object({
+    email: vine.string().trim().email(),
+    password: vine.string().minLength(6),
+  })
+)
+
+export default class AuthController {
+  public async register({ request, response }: HttpContext) {
+    const payload = await vine.validate({ schema: registerSchema, data: request.all() })
+
+    const existingUser = await User.findBy('email', payload.email)
+    if (existingUser) {
+      return response.conflict({ message: 'Email already registered' })
+    }
+
+    const user = await User.create({
+      name: payload.name,
+      email: payload.email,
+      password: payload.password,
+      role: payload.role ?? 'user',
+    })
+
+    return response.created({
+      message: 'Registration successful',
+      user: {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        role: user.role,
+      },
+    })
+  }
+
+  public async login({ request, auth, response }: HttpContext) {
+    const payload = await vine.validate({ schema: loginSchema, data: request.all() })
+
+    try {
+      const token = await auth.use('api').attempt(payload.email, payload.password, {
+        expiresIn: '7 days',
+      })
+
+      const user = auth.user!
+      return {
+        token: token.toJSON(),
+        user: {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          role: user.role,
+        },
+      }
+    } catch {
+      return response.unauthorized({ message: 'Invalid credentials' })
+    }
+  }
+}

--- a/backend/app/Controllers/Http/TodosController.ts
+++ b/backend/app/Controllers/Http/TodosController.ts
@@ -1,0 +1,117 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { DateTime } from 'luxon'
+import vine from '@vinejs/vine'
+import Todo from '#models/todo'
+
+const createSchema = vine.compile(
+  vine.object({
+    title: vine.string().trim().minLength(3),
+    description: vine.string().trim().minLength(3),
+    priority: vine.enum(['low', 'medium', 'high']),
+    status: vine.enum(['pending', 'in-progress', 'completed']).optional(),
+    dueDate: vine
+      .date({ formats: ['yyyy-MM-dd'] })
+      .optional()
+      .nullable(),
+  })
+)
+
+const updateSchema = vine.compile(
+  vine.object({
+    title: vine.string().trim().minLength(3).optional(),
+    description: vine.string().trim().minLength(3).optional(),
+    priority: vine.enum(['low', 'medium', 'high']).optional(),
+    status: vine.enum(['pending', 'in-progress', 'completed']).optional(),
+    dueDate: vine
+      .date({ formats: ['yyyy-MM-dd'] })
+      .optional()
+      .nullable(),
+  })
+)
+
+function parseDueDate(value: unknown): DateTime | null {
+  if (!value) {
+    return null
+  }
+
+  if (value instanceof Date) {
+    return DateTime.fromJSDate(value)
+  }
+
+  if (typeof value === 'string') {
+    const parsed = DateTime.fromISO(value)
+    return parsed.isValid ? parsed : null
+  }
+
+  return null
+}
+
+export default class TodosController {
+  public async index({ auth }: HttpContext) {
+    const user = await auth.authenticate()
+    return Todo.query().where('user_id', user.id).orderBy('created_at', 'desc')
+  }
+
+  public async store({ request, auth, response }: HttpContext) {
+    const user = await auth.authenticate()
+    const payload = await vine.validate({ schema: createSchema, data: request.all() })
+
+    const todo = await Todo.create({
+      title: payload.title,
+      description: payload.description,
+      priority: payload.priority,
+      status: payload.status ?? 'pending',
+      dueDate: parseDueDate(payload.dueDate),
+      userId: user.id,
+    })
+
+    return response.created(todo)
+  }
+
+  public async show({ params, auth, response }: HttpContext) {
+    const user = await auth.authenticate()
+    const todo = await Todo.query().where('id', params.id).andWhere('user_id', user.id).first()
+
+    if (!todo) {
+      return response.notFound({ message: 'Todo not found' })
+    }
+
+    return todo
+  }
+
+  public async update({ params, request, auth, response }: HttpContext) {
+    const user = await auth.authenticate()
+    const payload = await vine.validate({ schema: updateSchema, data: request.all() })
+
+    const todo = await Todo.query().where('id', params.id).andWhere('user_id', user.id).first()
+    if (!todo) {
+      return response.notFound({ message: 'Todo not found' })
+    }
+
+    if (payload.dueDate !== undefined) {
+      todo.dueDate = parseDueDate(payload.dueDate)
+    }
+
+    todo.merge({
+      title: payload.title ?? todo.title,
+      description: payload.description ?? todo.description,
+      priority: payload.priority ?? todo.priority,
+      status: payload.status ?? todo.status,
+    })
+
+    await todo.save()
+    return todo
+  }
+
+  public async destroy({ params, auth, response }: HttpContext) {
+    const user = await auth.authenticate()
+    const todo = await Todo.query().where('id', params.id).andWhere('user_id', user.id).first()
+
+    if (!todo) {
+      return response.notFound({ message: 'Todo not found' })
+    }
+
+    await todo.delete()
+    return response.noContent()
+  }
+}

--- a/backend/app/Middleware/role_middleware.ts
+++ b/backend/app/Middleware/role_middleware.ts
@@ -1,0 +1,14 @@
+export default class RoleMiddleware {
+  public async handle(ctx: any, next: () => Promise<void>, roles: string[]) {
+    await ctx.auth.authenticate()
+    const user = ctx.auth.user
+
+    if (!user || !roles.includes(user.role)) {
+      return ctx.response.unauthorized({
+        message: 'You are not authorized to access this resource',
+      })
+    }
+
+    await next()
+  }
+}

--- a/backend/app/Models/Todo.ts
+++ b/backend/app/Models/Todo.ts
@@ -1,0 +1,35 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, belongsTo, BelongsTo } from '@adonisjs/lucid/orm'
+import User from '#models/user'
+
+export default class Todo extends BaseModel {
+  @column({ isPrimary: true })
+  public id: number
+
+  @column()
+  public title: string
+
+  @column()
+  public description: string
+
+  @column()
+  public priority: 'low' | 'medium' | 'high'
+
+  @column()
+  public status: 'pending' | 'in-progress' | 'completed'
+
+  @column.date({ columnName: 'due_date' })
+  public dueDate: DateTime | null
+
+  @column({ columnName: 'user_id' })
+  public userId: number
+
+  @column.dateTime({ columnName: 'created_at', autoCreate: true })
+  public createdAt: DateTime
+
+  @column.dateTime({ columnName: 'updated_at', autoCreate: true, autoUpdate: true })
+  public updatedAt: DateTime
+
+  @belongsTo(() => User)
+  public user: BelongsTo<typeof User>
+}

--- a/backend/app/Models/User.ts
+++ b/backend/app/Models/User.ts
@@ -1,0 +1,37 @@
+import { DateTime } from 'luxon'
+import { BaseModel, beforeSave, column, hasMany, HasMany } from '@adonisjs/lucid/orm'
+import hash from '@adonisjs/core/services/hash'
+import Todo from '#models/todo'
+
+export default class User extends BaseModel {
+  @column({ isPrimary: true })
+  public id: number
+
+  @column()
+  public name: string
+
+  @column()
+  public email: string
+
+  @column({ serializeAs: null })
+  public password: string
+
+  @column()
+  public role: 'user' | 'admin'
+
+  @column.dateTime({ columnName: 'created_at', autoCreate: true })
+  public createdAt: DateTime
+
+  @column.dateTime({ columnName: 'updated_at', autoCreate: true, autoUpdate: true })
+  public updatedAt: DateTime
+
+  @hasMany(() => Todo)
+  public todos: HasMany<typeof Todo>
+
+  @beforeSave()
+  public static async hashPassword(user: User) {
+    if (user.$dirty.password) {
+      user.password = await hash.make(user.password)
+    }
+  }
+}

--- a/backend/config/app.ts
+++ b/backend/config/app.ts
@@ -1,0 +1,52 @@
+import app from '@adonisjs/core/services/app'
+import env from '@adonisjs/core/services/env'
+
+declare module '@adonisjs/core/types' {
+  interface AppConfig {
+    appKey: string
+    http: {
+      allowMethodSpoofing: boolean
+      generateRequestId: boolean
+      jsonpCallbackName: string
+      allowJsonp: boolean
+      cookie: {
+        domain: string
+        path: string
+        maxAge: string | number | undefined
+        httpOnly: boolean
+        secure: boolean
+        sameSite: boolean | 'lax' | 'strict' | 'none'
+      }
+    }
+    logger: {
+      name: string
+      level: string
+      enabled: boolean
+    }
+  }
+}
+
+const appConfig = {
+  appKey: env.get('APP_KEY'),
+  http: {
+    allowMethodSpoofing: false,
+    generateRequestId: true,
+    jsonpCallbackName: 'callback',
+    allowJsonp: false,
+    cookie: {
+      domain: '',
+      path: '/',
+      maxAge: '1h',
+      httpOnly: true,
+      secure: false,
+      sameSite: 'lax',
+    },
+  },
+  logger: {
+    name: app.appName,
+    level: env.get('LOG_LEVEL', 'info'),
+    enabled: true,
+  },
+}
+
+export default appConfig

--- a/backend/config/auth.ts
+++ b/backend/config/auth.ts
@@ -1,0 +1,22 @@
+import { AuthenticatorsConfig } from '@adonisjs/auth/types'
+
+const authConfig: AuthenticatorsConfig = {
+  default: 'api',
+  authenticators: {
+    api: {
+      driver: 'oat',
+      tokenProvider: {
+        driver: 'database',
+        table: 'api_tokens',
+      },
+      provider: {
+        driver: 'lucid',
+        identifierKey: 'id',
+        uids: ['email'],
+        model: () => import('#models/user'),
+      },
+    },
+  },
+}
+
+export default authConfig

--- a/backend/config/database.ts
+++ b/backend/config/database.ts
@@ -1,0 +1,25 @@
+import env from '@adonisjs/core/services/env'
+import { DatabaseConfig } from '@adonisjs/lucid/types/database'
+
+const databaseConfig: DatabaseConfig = {
+  connection: 'pg',
+  connections: {
+    pg: {
+      client: 'pg',
+      connection: {
+        host: env.get('PG_HOST', 'localhost'),
+        port: Number(env.get('PG_PORT', 5432)),
+        user: env.get('PG_USER', 'postgres'),
+        password: env.get('PG_PASSWORD', 'admin'),
+        database: env.get('PG_DB_NAME', 'Docapp3'),
+      },
+      migrations: {
+        naturalSort: true,
+      },
+      healthCheck: true,
+      debug: false,
+    },
+  },
+}
+
+export default databaseConfig

--- a/backend/database/migrations/1700000000000_users.ts
+++ b/backend/database/migrations/1700000000000_users.ts
@@ -1,0 +1,20 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class Users extends BaseSchema {
+  protected tableName = 'users'
+
+  public async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.string('name').notNullable()
+      table.string('email').notNullable().unique()
+      table.string('password').notNullable()
+      table.enum('role', ['user', 'admin']).defaultTo('user').notNullable()
+      table.timestamps(true)
+    })
+  }
+
+  public async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/database/migrations/1700000001000_todos.ts
+++ b/backend/database/migrations/1700000001000_todos.ts
@@ -1,0 +1,27 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class Todos extends BaseSchema {
+  protected tableName = 'todos'
+
+  public async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.string('title').notNullable()
+      table.text('description').notNullable()
+      table.enum('priority', ['low', 'medium', 'high']).defaultTo('medium').notNullable()
+      table.enum('status', ['pending', 'in-progress', 'completed']).defaultTo('pending').notNullable()
+      table.date('due_date').nullable()
+      table
+        .integer('user_id')
+        .unsigned()
+        .references('id')
+        .inTable('users')
+        .onDelete('CASCADE')
+      table.timestamps(true)
+    })
+  }
+
+  public async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/database/migrations/1700000002000_api_tokens.ts
+++ b/backend/database/migrations/1700000002000_api_tokens.ts
@@ -1,0 +1,26 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class ApiTokens extends BaseSchema {
+  protected tableName = 'api_tokens'
+
+  public async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').primary()
+      table.string('name').notNullable()
+      table.string('type').notNullable()
+      table.string('token', 64).notNullable().unique()
+      table.timestamp('expires_at', { useTz: true }).nullable()
+      table
+        .integer('user_id')
+        .unsigned()
+        .references('id')
+        .inTable('users')
+        .onDelete('CASCADE')
+      table.timestamps(true)
+    })
+  }
+
+  public async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/database/seeders/UserSeeder.ts
+++ b/backend/database/seeders/UserSeeder.ts
@@ -1,0 +1,46 @@
+import { DateTime } from 'luxon'
+import { BaseSeeder } from '@adonisjs/lucid/seeders'
+import User from '#models/user'
+import Todo from '#models/todo'
+
+export default class UserSeeder extends BaseSeeder {
+  public async run() {
+    const admin = await User.updateOrCreate(
+      { email: 'admin@example.com' },
+      {
+        name: 'Administrator',
+        password: 'admin123',
+        role: 'admin',
+      }
+    )
+
+    const user = await User.updateOrCreate(
+      { email: 'user@example.com' },
+      {
+        name: 'Regular User',
+        password: 'user123',
+        role: 'user',
+      }
+    )
+
+    await Todo.firstOrCreate(
+      { title: 'Review quarterly reports', userId: admin.id },
+      {
+        description: 'Analyze performance metrics and prepare presentation for leadership.',
+        priority: 'high',
+        status: 'in-progress',
+        dueDate: DateTime.now().plus({ days: 7 }),
+      }
+    )
+
+    await Todo.firstOrCreate(
+      { title: 'Complete onboarding checklist', userId: user.id },
+      {
+        description: 'Finish the required documents and setup accounts for new hire.',
+        priority: 'medium',
+        status: 'pending',
+        dueDate: DateTime.now().plus({ days: 3 }),
+      }
+    )
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "enterprise-todo-backend",
+  "version": "1.0.0",
+  "description": "Enterprise Todo backend built with AdonisJS v6",
+  "type": "module",
+  "scripts": {
+    "dev": "node ace serve --watch",
+    "build": "node ace build --production",
+    "lint": "eslint .",
+    "migration:run": "node ace migration:run",
+    "migration:refresh": "node ace migration:refresh",
+    "seed": "node ace db:seed"
+  },
+  "dependencies": {
+    "@adonisjs/auth": "^9.0.0",
+    "@adonisjs/bodyparser": "^8.0.0",
+    "@adonisjs/core": "^6.4.0",
+    "@adonisjs/lucid": "^21.4.0",
+    "@adonisjs/repl": "^4.0.0",
+    "@vinejs/vine": "^1.7.0",
+    "luxon": "^3.4.0",
+    "pg": "^8.11.0",
+    "reflect-metadata": "^0.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.0",
+    "prettier": "^3.2.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,0 +1,8 @@
+import 'reflect-metadata'
+import { Ignitor } from '@adonisjs/core/ignitor'
+import { fileURLToPath } from 'node:url'
+import { dirname } from 'node:path'
+
+const appRoot = dirname(fileURLToPath(import.meta.url))
+
+new Ignitor(appRoot).httpServer().start()

--- a/backend/start/kernel.ts
+++ b/backend/start/kernel.ts
@@ -1,0 +1,11 @@
+import server from '@adonisjs/core/services/server'
+
+server.middleware.register([
+  () => import('@adonisjs/bodyparser/middleware'),
+])
+
+server.middleware.registerNamed({
+  auth: () => import('@adonisjs/auth/middleware/auth_middleware'),
+  silentAuth: () => import('@adonisjs/auth/middleware/silent_auth_middleware'),
+  role: () => import('#middleware/role_middleware'),
+})

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -1,0 +1,24 @@
+import router from '@adonisjs/core/services/router'
+
+router.post('/register', 'AuthController.register')
+router.post('/login', 'AuthController.login')
+
+router
+  .group(() => {
+    router.get('/todos', 'TodosController.index')
+    router.post('/todos', 'TodosController.store')
+    router.get('/todos/:id', 'TodosController.show')
+    router.put('/todos/:id', 'TodosController.update')
+    router.delete('/todos/:id', 'TodosController.destroy')
+  })
+  .middleware(['auth'])
+
+router
+  .group(() => {
+    router.get('/users', 'AdminController.users')
+    router.get('/todos', 'AdminController.todos')
+    router.put('/todos/:id', 'AdminController.updateTodo')
+    router.delete('/todos/:id', 'AdminController.deleteTodo')
+  })
+  .prefix('/admin')
+  .middleware(['auth', 'role:admin'])

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./node_modules/@adonisjs/core/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build",
+    "baseUrl": "./",
+    "paths": {
+      "#controllers/*": ["app/Controllers/*"],
+      "#models/*": ["app/Models/*"],
+      "#validators/*": ["app/Validators/*"],
+      "#middleware/*": ["app/Middleware/*"],
+      "#utils/*": ["app/Utils/*"]
+    }
+  }
+}

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3333

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Enterprise Todo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "enterprise-todo-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.8",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.55",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.1.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,90 @@
+import { Navigate, Route, Routes, Link, useNavigate } from 'react-router-dom'
+import { useAuth } from './hooks/useAuth'
+import LoginForm from './components/LoginForm'
+import RegisterForm from './components/RegisterForm'
+import UserDashboard from './pages/UserDashboard'
+import AdminDashboard from './pages/AdminDashboard'
+
+function PrivateRoute({ children }) {
+  const { isAuthenticated } = useAuth()
+  return isAuthenticated ? children : <Navigate to="/login" replace />
+}
+
+function AdminRoute({ children }) {
+  const { isAuthenticated, user } = useAuth()
+  if (!isAuthenticated) return <Navigate to="/login" replace />
+  if (user?.role !== 'admin') return <Navigate to="/dashboard" replace />
+  return children
+}
+
+function Navigation() {
+  const { isAuthenticated, user, logout } = useAuth()
+  const navigate = useNavigate()
+
+  const handleLogout = () => {
+    logout()
+    navigate('/login')
+  }
+
+  return (
+    <header className="navbar">
+      <div>
+        <Link to="/dashboard">Enterprise Todo</Link>
+      </div>
+      <nav>
+        {isAuthenticated ? (
+          <>
+            <span style={{ marginRight: '1rem', fontWeight: 600 }}>Hello, {user?.name}</span>
+            {user?.role === 'admin' && (
+              <Link to="/admin" style={{ marginRight: '1rem' }}>
+                Admin
+              </Link>
+            )}
+            <button className="secondary" onClick={handleLogout} type="button">
+              Logout
+            </button>
+          </>
+        ) : (
+          <>
+            <Link to="/login">Login</Link>
+            <Link to="/register" style={{ marginLeft: '1rem' }}>
+              Register
+            </Link>
+          </>
+        )}
+      </nav>
+    </header>
+  )
+}
+
+export default function App() {
+  return (
+    <div className="app-shell">
+      <Navigation />
+      <main className="main-content">
+        <Routes>
+          <Route path="/" element={<Navigate to="/login" replace />} />
+          <Route path="/login" element={<LoginForm />} />
+          <Route path="/register" element={<RegisterForm />} />
+          <Route
+            path="/dashboard"
+            element={
+              <PrivateRoute>
+                <UserDashboard />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/admin"
+            element={
+              <AdminRoute>
+                <AdminDashboard />
+              </AdminRoute>
+            }
+          />
+          <Route path="*" element={<Navigate to="/dashboard" replace />} />
+        </Routes>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -1,0 +1,81 @@
+export default function AdminPanel({ users, todos, onRefresh, onEditTodo, onDeleteTodo }) {
+  const formatDate = (value) => {
+    if (!value) return '—'
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? '—' : date.toLocaleDateString()
+  }
+
+  return (
+    <div className="card">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h2 style={{ margin: 0 }}>Admin oversight</h2>
+        <button className="secondary" type="button" onClick={onRefresh}>
+          Refresh data
+        </button>
+      </div>
+      <section style={{ marginTop: '1.5rem' }}>
+        <h3>Users</h3>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Role</th>
+              <th>Joined</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((user) => (
+              <tr key={user.id}>
+                <td>{user.name}</td>
+                <td>{user.email}</td>
+                <td style={{ textTransform: 'capitalize' }}>{user.role}</td>
+                <td>{formatDate(user.created_at ?? user.createdAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section style={{ marginTop: '2rem' }}>
+        <h3>Todos</h3>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Owner</th>
+              <th>Priority</th>
+              <th>Status</th>
+              <th>Due date</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {todos.map((todo) => (
+              <tr key={todo.id}>
+                <td>{todo.title}</td>
+                <td>{todo.user?.name ?? 'Unknown'}</td>
+                <td style={{ textTransform: 'capitalize' }}>{todo.priority}</td>
+                <td style={{ textTransform: 'capitalize' }}>{todo.status}</td>
+                <td>{formatDate(todo.dueDate)}</td>
+                <td>
+                  <button className="secondary" type="button" onClick={() => onEditTodo(todo)}>
+                    Edit
+                  </button>
+                  <button
+                    className="secondary"
+                    type="button"
+                    style={{ marginLeft: '0.5rem' }}
+                    onClick={() => onDeleteTodo(todo.id)}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import api from '../services/api'
+import { useAuth } from '../hooks/useAuth'
+
+export default function LoginForm() {
+  const navigate = useNavigate()
+  const { login, isAuthenticated, user } = useAuth()
+  const [form, setForm] = useState({ email: '', password: '' })
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      if (user?.role === 'admin') {
+        navigate('/admin', { replace: true })
+      } else {
+        navigate('/dashboard', { replace: true })
+      }
+    }
+  }, [isAuthenticated, user, navigate])
+
+  const handleChange = (event) => {
+    setForm({ ...form, [event.target.name]: event.target.value })
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    setLoading(true)
+    setError('')
+
+    try {
+      const { data } = await api.post('/login', form)
+      login(data.token, data.user)
+      if (data.user.role === 'admin') {
+        navigate('/admin', { replace: true })
+      } else {
+        navigate('/dashboard', { replace: true })
+      }
+    } catch (err) {
+      setError(err.response?.data?.message || 'Unable to login. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="card" style={{ maxWidth: 420, margin: '0 auto' }}>
+      <h2 style={{ marginTop: 0 }}>Welcome back</h2>
+      <p>Sign in to manage your todos.</p>
+      <form className="form-grid" onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input name="email" type="email" value={form.email} onChange={handleChange} required />
+        </label>
+        <label>
+          Password
+          <input
+            name="password"
+            type="password"
+            value={form.password}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        {error && <div style={{ color: '#b91c1c', fontWeight: 600 }}>{error}</div>}
+        <button className="primary" type="submit" disabled={loading}>
+          {loading ? 'Signing in…' : 'Login'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/components/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm.jsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import api from '../services/api'
+
+export default function RegisterForm() {
+  const navigate = useNavigate()
+  const [form, setForm] = useState({ name: '', email: '', password: '', role: 'user' })
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [success, setSuccess] = useState('')
+
+  const handleChange = (event) => {
+    setForm({ ...form, [event.target.name]: event.target.value })
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    setLoading(true)
+    setError('')
+    setSuccess('')
+
+    try {
+      await api.post('/register', form)
+      setSuccess('Registration successful! You can now login.')
+      setTimeout(() => navigate('/login'), 800)
+    } catch (err) {
+      setError(err.response?.data?.message || 'Unable to register. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="card" style={{ maxWidth: 420, margin: '0 auto' }}>
+      <h2 style={{ marginTop: 0 }}>Create your account</h2>
+      <p>Start managing your todos in minutes.</p>
+      <form className="form-grid" onSubmit={handleSubmit}>
+        <label>
+          Name
+          <input name="name" value={form.name} onChange={handleChange} required />
+        </label>
+        <label>
+          Email
+          <input name="email" type="email" value={form.email} onChange={handleChange} required />
+        </label>
+        <label>
+          Password
+          <input
+            name="password"
+            type="password"
+            value={form.password}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        <label>
+          Role
+          <select name="role" value={form.role} onChange={handleChange}>
+            <option value="user">User</option>
+            <option value="admin">Admin</option>
+          </select>
+        </label>
+        {error && <div style={{ color: '#b91c1c', fontWeight: 600 }}>{error}</div>}
+        {success && <div style={{ color: '#15803d', fontWeight: 600 }}>{success}</div>}
+        <button className="primary" type="submit" disabled={loading}>
+          {loading ? 'Creating account…' : 'Register'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/components/TodoForm.jsx
+++ b/frontend/src/components/TodoForm.jsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react'
+
+const initialState = {
+  title: '',
+  description: '',
+  priority: 'medium',
+  status: 'pending',
+  dueDate: '',
+  userId: '',
+}
+
+export default function TodoForm({
+  onSubmit,
+  submitting,
+  selectedTodo,
+  onCancel,
+  users = [],
+  allowUserSelection = false,
+}) {
+  const [form, setForm] = useState({ ...initialState })
+
+  useEffect(() => {
+    if (selectedTodo) {
+      setForm({
+        title: selectedTodo.title,
+        description: selectedTodo.description,
+        priority: selectedTodo.priority,
+        status: selectedTodo.status,
+        dueDate: selectedTodo.dueDate ? selectedTodo.dueDate.substring(0, 10) : '',
+        userId: selectedTodo.userId?.toString() || selectedTodo.user?.id?.toString() || '',
+      })
+    } else {
+      setForm({ ...initialState })
+    }
+  }, [selectedTodo])
+
+  const handleChange = (event) => {
+    setForm({ ...form, [event.target.name]: event.target.value })
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    const payload = {
+      ...form,
+      userId: allowUserSelection && form.userId ? Number(form.userId) : undefined,
+    }
+    onSubmit(payload)
+  }
+
+  return (
+    <div className="card">
+      <h3 style={{ marginTop: 0 }}>{selectedTodo ? 'Update todo' : 'Create a new todo'}</h3>
+      <form className="form-grid" onSubmit={handleSubmit}>
+        <label>
+          Title
+          <input name="title" value={form.title} onChange={handleChange} required />
+        </label>
+        <label>
+          Description
+          <textarea name="description" value={form.description} onChange={handleChange} required />
+        </label>
+        <label>
+          Priority
+          <select name="priority" value={form.priority} onChange={handleChange}>
+            <option value="low">Low</option>
+            <option value="medium">Medium</option>
+            <option value="high">High</option>
+          </select>
+        </label>
+        <label>
+          Status
+          <select name="status" value={form.status} onChange={handleChange}>
+            <option value="pending">Pending</option>
+            <option value="in-progress">In Progress</option>
+            <option value="completed">Completed</option>
+          </select>
+        </label>
+        <label>
+          Due date
+          <input name="dueDate" type="date" value={form.dueDate} onChange={handleChange} />
+        </label>
+        {allowUserSelection && (
+          <label>
+            Assign to user
+            <select name="userId" value={form.userId} onChange={handleChange} required>
+              <option value="">Select a user</option>
+              {users.map((user) => (
+                <option key={user.id} value={user.id}>
+                  {user.name} ({user.role})
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        <div style={{ display: 'flex', gap: '1rem', justifyContent: 'flex-end' }}>
+          {selectedTodo && (
+            <button className="secondary" type="button" onClick={onCancel} disabled={submitting}>
+              Cancel
+            </button>
+          )}
+          <button className="primary" type="submit" disabled={submitting}>
+            {submitting ? 'Saving…' : selectedTodo ? 'Update todo' : 'Create todo'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/components/TodoList.jsx
+++ b/frontend/src/components/TodoList.jsx
@@ -1,0 +1,44 @@
+const formatDate = (value) => {
+  if (!value) return 'Not set'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? 'Not set' : date.toLocaleDateString()
+}
+
+export default function TodoList({ todos, onEdit, onDelete }) {
+  if (!todos.length) {
+    return (
+      <div className="card">
+        <p style={{ margin: 0 }}>No todos found yet. Create your first one!</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="card">
+      <h3 style={{ marginTop: 0 }}>Your todos</h3>
+      {todos.map((todo) => (
+        <div className="todo-item" key={todo.id}>
+          <div className="todo-item-header">
+            <div>
+              <h4 style={{ margin: '0 0 0.25rem 0' }}>{todo.title}</h4>
+              <small>Due: {formatDate(todo.dueDate)}</small>
+            </div>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <span className={`badge ${todo.priority}`}>{todo.priority}</span>
+              <span className={`badge ${todo.status}`}>{todo.status}</span>
+            </div>
+          </div>
+          <p style={{ marginTop: '0.5rem' }}>{todo.description}</p>
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <button className="secondary" type="button" onClick={() => onEdit(todo)}>
+              Edit
+            </button>
+            <button className="secondary" type="button" onClick={() => onDelete(todo.id)}>
+              Delete
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,51 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
+
+const AuthContext = createContext(null)
+
+const STORAGE_KEY = 'enterprise_todo_auth'
+
+function getStoredState() {
+  if (typeof window === 'undefined') {
+    return { token: null, user: null }
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  if (stored) {
+    try {
+      return JSON.parse(stored)
+    } catch (error) {
+      console.error('Failed to parse auth state', error)
+    }
+  }
+  return { token: null, user: null }
+}
+
+export function AuthProvider({ children }) {
+  const [authState, setAuthState] = useState(getStoredState)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(authState))
+    }
+  }, [authState])
+
+  const value = useMemo(
+    () => ({
+      ...authState,
+      isAuthenticated: Boolean(authState?.token),
+      login: (token, user) => setAuthState({ token, user }),
+      logout: () => setAuthState({ token: null, user: null }),
+    }),
+    [authState]
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export function useAuthContext() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuthContext must be used within an AuthProvider')
+  }
+  return context
+}

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,0 +1,5 @@
+import { useAuthContext } from '../context/AuthContext'
+
+export function useAuth() {
+  return useAuthContext()
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import { AuthProvider } from './context/AuthContext'
+import './styles.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+)

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react'
+import api from '../services/api'
+import AdminPanel from '../components/AdminPanel'
+import TodoForm from '../components/TodoForm'
+
+const normalizeTodo = (todo) => ({
+  ...todo,
+  dueDate: todo.dueDate ?? todo.due_date ?? null,
+  userId: todo.userId ?? todo.user_id ?? todo.user?.id,
+})
+
+export default function AdminDashboard() {
+  const [users, setUsers] = useState([])
+  const [todos, setTodos] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [editingTodo, setEditingTodo] = useState(null)
+  const [saving, setSaving] = useState(false)
+  const [feedback, setFeedback] = useState('')
+
+  const fetchData = async () => {
+    setLoading(true)
+    setFeedback('')
+    try {
+      const [usersResponse, todosResponse] = await Promise.all([
+        api.get('/admin/users'),
+        api.get('/admin/todos'),
+      ])
+      setUsers(usersResponse.data)
+      setTodos(todosResponse.data.map(normalizeTodo))
+    } catch (error) {
+      console.error('Failed to fetch admin data', error)
+      setFeedback(error.response?.data?.message || 'Unable to load admin data.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchData()
+  }, [])
+
+  const handleTodoUpdate = async (formValues) => {
+    if (!editingTodo) return
+    setSaving(true)
+    setFeedback('')
+    const payload = {
+      ...formValues,
+      userId: formValues.userId || editingTodo.user?.id || editingTodo.userId,
+      dueDate: formValues.dueDate || null,
+    }
+
+    try {
+      await api.put(`/admin/todos/${editingTodo.id}`, payload)
+      setFeedback('Todo updated successfully.')
+      setEditingTodo(null)
+      fetchData()
+    } catch (error) {
+      setFeedback(error.response?.data?.message || 'Failed to update todo.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleTodoDelete = async (id) => {
+    if (!window.confirm('Delete this todo permanently?')) return
+    try {
+      await api.delete(`/admin/todos/${id}`)
+      setFeedback('Todo deleted successfully.')
+      fetchData()
+    } catch (error) {
+      setFeedback(error.response?.data?.message || 'Failed to delete todo.')
+    }
+  }
+
+  return (
+    <div>
+      <h1 style={{ marginTop: 0 }}>Admin dashboard</h1>
+      <p>Monitor all activity across the organization.</p>
+      {feedback && <div style={{ marginBottom: '1rem', color: '#1d4ed8', fontWeight: 600 }}>{feedback}</div>}
+      {loading ? (
+        <div className="card">Loading data…</div>
+      ) : (
+        <AdminPanel
+          users={users}
+          todos={todos}
+          onRefresh={fetchData}
+          onEditTodo={(todo) => setEditingTodo(normalizeTodo(todo))}
+          onDeleteTodo={handleTodoDelete}
+        />
+      )}
+      {editingTodo && (
+        <TodoForm
+          onSubmit={handleTodoUpdate}
+          submitting={saving}
+          selectedTodo={editingTodo}
+          onCancel={() => setEditingTodo(null)}
+          users={users}
+          allowUserSelection
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/UserDashboard.jsx
+++ b/frontend/src/pages/UserDashboard.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+import api from '../services/api'
+import { useAuth } from '../hooks/useAuth'
+import TodoForm from '../components/TodoForm'
+import TodoList from '../components/TodoList'
+
+const normalizeTodo = (todo) => ({
+  ...todo,
+  dueDate: todo.dueDate ?? todo.due_date ?? null,
+  userId: todo.userId ?? todo.user_id,
+})
+
+export default function UserDashboard() {
+  const { user } = useAuth()
+  const [todos, setTodos] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [selectedTodo, setSelectedTodo] = useState(null)
+  const [feedback, setFeedback] = useState('')
+
+  const fetchTodos = async () => {
+    setLoading(true)
+    try {
+      const { data } = await api.get('/todos')
+      setTodos(data.map(normalizeTodo))
+    } catch (error) {
+      console.error('Failed to fetch todos', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchTodos()
+  }, [])
+
+  const handleSubmit = async (formValues) => {
+    setSaving(true)
+    setFeedback('')
+    const payload = { ...formValues, dueDate: formValues.dueDate || null }
+    try {
+      if (selectedTodo) {
+        await api.put(`/todos/${selectedTodo.id}`, payload)
+        setFeedback('Todo updated successfully.')
+      } else {
+        await api.post('/todos', payload)
+        setFeedback('Todo created successfully.')
+      }
+      setSelectedTodo(null)
+      fetchTodos()
+    } catch (error) {
+      setFeedback(error.response?.data?.message || 'Something went wrong, please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Are you sure you want to delete this todo?')) return
+    try {
+      await api.delete(`/todos/${id}`)
+      setFeedback('Todo removed successfully.')
+      fetchTodos()
+    } catch (error) {
+      setFeedback(error.response?.data?.message || 'Failed to delete todo.')
+    }
+  }
+
+  return (
+    <div>
+      <h1 style={{ marginTop: 0 }}>Dashboard</h1>
+      <p>Manage your work effortlessly. Signed in as {user?.name}.</p>
+      {feedback && <div style={{ marginBottom: '1rem', color: '#1d4ed8', fontWeight: 600 }}>{feedback}</div>}
+      <TodoForm
+        onSubmit={handleSubmit}
+        submitting={saving}
+        selectedTodo={selectedTodo}
+        onCancel={() => setSelectedTodo(null)}
+      />
+      {loading ? (
+        <div className="card">Loading todos…</div>
+      ) : (
+        <TodoList
+          todos={todos}
+          onEdit={(todo) => setSelectedTodo(normalizeTodo(todo))}
+          onDelete={handleDelete}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,25 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3333',
+})
+
+api.interceptors.request.use((config) => {
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('enterprise_todo_auth')
+    if (stored) {
+      try {
+        const { token } = JSON.parse(stored)
+        if (token) {
+          const value = token.token ?? token
+          config.headers.Authorization = `Bearer ${value}`
+        }
+      } catch (error) {
+        console.error('Failed to parse auth token', error)
+      }
+    }
+  }
+  return config
+})
+
+export default api

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,154 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  cursor: pointer;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: #1d4ed8;
+  color: #fff;
+}
+
+.navbar a {
+  color: #bfdbfe;
+  margin-right: 1rem;
+}
+
+.main-content {
+  flex: 1;
+  padding: 2rem;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  margin-bottom: 1.5rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  font-size: 1rem;
+}
+
+button.primary {
+  background: #1d4ed8;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+button.secondary {
+  background: transparent;
+  color: #1d4ed8;
+  border: 1px solid #1d4ed8;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+}
+
+.todo-item {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.todo-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.badge.low {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.badge.medium {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.badge.high {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.badge.pending {
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.badge.in-progress {
+  background: #e0f2fe;
+  color: #0369a1;
+}
+
+.badge.completed {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.table tbody tr:hover {
+  background: #f8fafc;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+})


### PR DESCRIPTION
## Summary
- scaffold an AdonisJS v6 API with JWT auth, role middleware, migrations, and seed data for admin and user accounts
- expose todo and admin management controllers with Lucid models, validation, and RESTful routing for role-aware CRUD
- add a React Vite dashboard with auth context, protected routing, user/admin views, and axios integration against the backend API

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd4adf7b548330916f205247d6e444